### PR TITLE
Support passing authentication as part of URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ and probing for the correct protocol to use.
 ```php
 $factory->createClient('localhost')->then(
     function (Client $client) {
-        // client connected
+        // client connected (and authenticated)
     },
     function (Exception $e) {
-        // an error occured while trying to connect client
+        // an error occured while trying to connect (or authenticate) client
     }
 );
 ```
@@ -89,6 +89,27 @@ if your Quassel IRC core is not using the default TCP/IP port `4242`:
 ```php
 $factory->createClient('quassel://localhost:4242');
 ```
+
+Quassel supports password-based authentication. If you want to create a "normal"
+client connection, you're recommended to pass the authentication details as part
+of the URI. You can pass the password `h@llo` URL-encoded (percent-encoded) as
+part of the URI like this:
+
+```php
+$factory->createClient('quassel://user:h%40llo@localhost')->then(
+    function (Client $client) {
+        // client sucessfully connected and authenticated
+        $client->on('data', function ($data) {
+            // next message to follow would be "SessionInit"
+        });
+    }
+);
+```
+
+Note that if you do not pass the authentication details as part of the URI, then
+this method will resolve with a "bare" `Client` right after connecting without
+sending any application messages. This can be useful if you need full control
+over the message flow, see below for more details.
 
 >   This method uses Quassel IRC's probing mechanism for the correct protocol to
     use (newer "datastream" protocol or original "legacy" protocol).

--- a/examples/01-channels.php
+++ b/examples/01-channels.php
@@ -5,57 +5,31 @@ use Clue\React\Quassel\Client;
 use Clue\React\Quassel\Io\Protocol;
 
 require __DIR__ . '/../vendor/autoload.php';
+
 $host = '127.0.0.1';
-$user = array();
 if (isset($argv[1])) { $host = $argv[1]; }
 
 echo 'Server: ' . $host . PHP_EOL;
 
 echo 'User name: ';
-$user['name'] = trim(fgets(STDIN));
+$user = trim(fgets(STDIN));
 
 echo 'Password: ';
-$user['password'] = trim(fgets(STDIN));
+$pass = trim(fgets(STDIN));
 
 $loop = \React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 
-$factory->createClient($host)->then(function (Client $client) use ($loop, $user) {
+$uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
+
+$factory->createClient($uri)->then(function (Client $client) {
     var_dump('CONNECTED');
 
     $await = array();
 
-    $client->on('data', function ($message) use ($client, $user, &$await) {
-        $type = null;
-        if (is_array($message) && isset($message['MsgType'])) {
-            $type = $message['MsgType'];
-        }
-
-        if ($type === 'ClientInitAck') {
-            if (!$message['Configured']) {
-                var_dump('core not configured yet');
-                $client->close();
-                return;
-            }
-            var_dump('core ready, now logging in');
-            $client->writeClientLogin($user['name'], $user['password']);
-
-            return;
-        }
-        if ($type === 'ClientLoginReject') {
-            var_dump('Unable to login', $message['Error']);
-
-            var_dump('Now closing connection');
-            $client->close();
-
-            return;
-        }
-        if ($type === 'ClientLoginAck') {
-            var_dump('successfully logged in, now waiting for a SessionInit message');
-
-            return;
-        }
-        if ($type === 'SessionInit') {
+    $client->on('data', function ($message) use ($client, &$await) {
+        // session initialized => initialize all networks
+        if (isset($message['MsgType']) && $message['MsgType'] === 'SessionInit') {
             var_dump('session initialized');
 
             foreach ($message['SessionState']['NetworkIds'] as $nid) {
@@ -104,8 +78,6 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
     $client->on('close', function () {
         echo 'Connection closed' . PHP_EOL;
     });
-
-    $client->writeClientInit();
 })->then(null, function ($e) {
     echo $e;
 });

--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -5,62 +5,36 @@ use Clue\React\Quassel\Client;
 use Clue\React\Quassel\Io\Protocol;
 
 require __DIR__ . '/../vendor/autoload.php';
+
 $host = '127.0.0.1';
-$user = array();
 if (isset($argv[1])) { $host = $argv[1]; }
 
 echo 'Server: ' . $host . PHP_EOL;
 
 echo 'User name: ';
-$user['name'] = trim(fgets(STDIN));
+$user = trim(fgets(STDIN));
 
 echo 'Password: ';
-$user['password'] = trim(fgets(STDIN));
+$pass = trim(fgets(STDIN));
 
 echo 'Keyword: ';
-$user['keyword'] = trim(fgets(STDIN));
+$keyword = trim(fgets(STDIN));
 
-if (strlen($user['keyword']) < 3) {
+if (strlen($keyword) < 3) {
     die('Keyword MUST contain at least 3 characters to avoid excessive spam');
 }
 
 $loop = \React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 
-$factory->createClient($host)->then(function (Client $client) use ($loop, $user) {
+$uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
+
+$factory->createClient($uri)->then(function (Client $client) use ($loop, $keyword) {
     var_dump('CONNECTED');
 
-    $client->on('data', function ($message) use ($client, $user, $loop) {
-        $type = null;
-        if (is_array($message) && isset($message['MsgType'])) {
-            $type = $message['MsgType'];
-        }
-
-        if ($type === 'ClientInitAck') {
-            if (!$message['Configured']) {
-                var_dump('core not configured yet');
-                $client->close();
-                return;
-            }
-            var_dump('core ready, now logging in');
-            $client->writeClientLogin($user['name'], $user['password']);
-
-            return;
-        }
-        if ($type === 'ClientLoginReject') {
-            var_dump('Unable to login', $message['Error']);
-
-            var_dump('Now closing connection');
-            $client->close();
-
-            return;
-        }
-        if ($type === 'ClientLoginAck') {
-            var_dump('successfully logged in, now waiting for a SessionInit message');
-
-            return;
-        }
-        if ($type === 'SessionInit') {
+    $client->on('data', function ($message) use ($client, $keyword, $loop) {
+        // session initialized
+        if (isset($message['MsgType']) && $message['MsgType']=== 'SessionInit') {
             var_dump('session initialized, now waiting for incoming messages');
 
             // send heartbeat message every 30s to check dropped connection
@@ -87,7 +61,7 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
         if (isset($message[0]) && $message[0] === Protocol::REQUEST_RPCCALL && $message[1] === '2displayMsg(Message)') {
             $data = $message[2];
 
-            if (strpos($data['content'], $user['keyword']) !== false) {
+            if (strpos($data['content'], $keyword) !== false) {
                 $client->writeBufferInput($data['bufferInfo'], 'Hello from clue/quassel-react :-)');
 
                 echo date('Y-m-d H:i:s') . ' Replied to ' . $data['bufferInfo']['name'] . '/' . explode('!', $data['sender'], 2)[0] . ': "' . $data['content'] . '"' . PHP_EOL;
@@ -99,8 +73,6 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
     $client->on('close', function () {
         echo 'Connection closed' . PHP_EOL;
     });
-
-    $client->writeClientInit();
 })->then(null, function ($e) {
     echo $e;
 });

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -5,57 +5,31 @@ use Clue\React\Quassel\Client;
 use Clue\React\Quassel\Io\Protocol;
 
 require __DIR__ . '/../vendor/autoload.php';
+
 $host = '127.0.0.1';
-$user = array();
 if (isset($argv[1])) { $host = $argv[1]; }
 
 echo 'Server: ' . $host . PHP_EOL;
 
 echo 'User name: ';
-$user['name'] = trim(fgets(STDIN));
+$user = trim(fgets(STDIN));
 
 echo 'Password: ';
-$user['password'] = trim(fgets(STDIN));
+$pass = trim(fgets(STDIN));
 
 $loop = \React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 
-$factory->createClient($host)->then(function (Client $client) use ($loop, $user) {
+$uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
+
+$factory->createClient($uri)->then(function (Client $client) use ($loop) {
     var_dump('CONNECTED');
 
     $nicks = array();
 
-    $client->on('data', function ($message) use ($client, $user, &$nicks, $loop) {
-        $type = null;
-        if (is_array($message) && isset($message['MsgType'])) {
-            $type = $message['MsgType'];
-        }
-
-        if ($type === 'ClientInitAck') {
-            if (!$message['Configured']) {
-                var_dump('core not configured yet');
-                $client->close();
-                return;
-            }
-            var_dump('core ready, now logging in');
-            $client->writeClientLogin($user['name'], $user['password']);
-
-            return;
-        }
-        if ($type === 'ClientLoginReject') {
-            var_dump('Unable to login', $message['Error']);
-
-            var_dump('Now closing connection');
-            $client->close();
-
-            return;
-        }
-        if ($type === 'ClientLoginAck') {
-            var_dump('successfully logged in, now waiting for a SessionInit message');
-
-            return;
-        }
-        if ($type === 'SessionInit') {
+    $client->on('data', function ($message) use ($client, &$nicks, $loop) {
+        // session initialized => initialize all networks
+        if (isset($message['MsgType']) && $message['MsgType'] === 'SessionInit') {
             var_dump('session initialized, now waiting for incoming messages');
 
             foreach ($message['SessionState']['NetworkIds'] as $nid) {
@@ -136,8 +110,6 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
     $client->on('close', function () {
         echo 'Connection closed' . PHP_EOL;
     });
-
-    $client->writeClientInit();
 })->then(null, function ($e) {
     echo $e;
 });

--- a/examples/11-debug.php
+++ b/examples/11-debug.php
@@ -1,0 +1,129 @@
+<?php
+
+use Clue\React\Quassel\Factory;
+use Clue\React\Quassel\Client;
+use Clue\React\Quassel\Io\Protocol;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$host = '127.0.0.1';
+$user = array();
+if (isset($argv[1])) { $host = $argv[1]; }
+
+echo 'Server: ' . $host . PHP_EOL;
+
+echo 'User name: ';
+$user['name'] = trim(fgets(STDIN));
+
+echo 'Password: ';
+$user['password'] = trim(fgets(STDIN));
+
+$loop = \React\EventLoop\Factory::create();
+$factory = new Factory($loop);
+
+echo '[1/5] Connecting' . PHP_EOL;
+$factory->createClient($host)->then(function (Client $client) use ($loop, $user) {
+    echo '[2/5] Connected, now initializing' . PHP_EOL;
+    $client->writeClientInit();
+
+    $client->on('data', function ($message) use ($client, $user, $loop) {
+        if (isset($message[3]['IrcUsersAndChannels'])) {
+            // print network information except for huge users/channels list
+            $debug = $message;
+            unset($debug[3]['IrcUsersAndChannels']);
+            echo 'Debug (shortened): ' . json_encode($debug, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) . PHP_EOL;
+        } else {
+            echo 'Debug: ' . json_encode($message, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE) . PHP_EOL;
+        }
+
+        $type = null;
+        if (is_array($message) && isset($message['MsgType'])) {
+            $type = $message['MsgType'];
+        }
+
+        if ($type === 'ClientInitAck') {
+            if (!$message['Configured']) {
+                echo '[3/5] Initialization done, but core is not configured yet, you may want to issue a setup call manually' . PHP_EOL;
+                print_r($message['StorageBackends']);
+
+                echo 'Hit enter to set-up server with defaults, otherwise cancel program now';
+                fgets(STDIN);
+
+                $client->writeCoreSetupData($user['name'], $user['password']);
+
+                return;
+            }
+            echo '[3/5] Initialized, now logging in' . PHP_EOL;
+            $client->writeClientLogin($user['name'], $user['password']);
+
+            return;
+        }
+        if ($type === 'CoreSetupAck') {
+            echo '[3/5] Core successfully configured, now logging in' . PHP_EOL;
+            $client->writeClientLogin($user['name'], $user['password']);
+
+            return;
+        }
+        if ($type === 'CoreSetupReject') {
+            echo '[3/5] Failed to set up core! ' . $message['Error'] . PHP_EOL;
+            $client->close();
+
+            return;
+        }
+        if ($type === 'ClientLoginReject') {
+            echo '[4/5] Failed to log in! ' . $message['Error'] . PHP_EOL;
+            $client->close();
+
+            return;
+        }
+        if ($type === 'ClientLoginAck') {
+            echo '[4/5] Logged in, now waiting for session' . PHP_EOL;
+
+            return;
+        }
+        if ($type === 'SessionInit') {
+            echo '[5/5] Session initialized, we are ready to go!' . PHP_EOL;
+
+            foreach ($message['SessionState']['NetworkIds'] as $nid) {
+                var_dump('requesting Network for ' . $nid . ', this may take a few seconds');
+                $client->writeInitRequest("Network", $nid);
+            }
+
+            foreach ($message['SessionState']['BufferInfos'] as $buffer) {
+                if ($buffer['type'] === 2) { // type == 4 for user
+                    var_dump('requesting IrcChannel for ' . $buffer['name']);
+                    $client->writeInitRequest('IrcChannel', $buffer['network'] . '/' . $buffer['id']);
+                }
+            }
+
+            // send heartbeat message every 30s to check dropped connection
+            $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
+                $client->writeHeartBeatRequest();
+            });
+
+            // stop heartbeat timer once connection closes
+            $client->on('close', function () use ($loop, $timer) {
+                $loop->cancelTimer($timer);
+            });
+
+            return;
+        }
+
+        // reply to heartbeat messages to avoid timing out
+        if (isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEAT) {
+            //var_dump('heartbeat', $message[1]);
+            $client->writeHeartBeatReply($message[1]);
+
+            return;
+        }
+    });
+
+    $client->on('error', 'printf');
+    $client->on('close', function () {
+        echo 'Connection closed' . PHP_EOL;
+    });
+})->then(null, function ($e) {
+    echo $e;
+});
+
+$loop->run();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -111,6 +111,12 @@ class Factory
                     return;
                 }
 
+                // reject if core rejects initialization
+                if ($type === 'ClientInitReject') {
+                    $reject(new \RuntimeException('Connection rejected by Quassel core: ' . $data['Error']));
+                    return $client->close();
+                }
+
                 // reject promise if login is rejected
                 if ($type === 'ClientLoginReject') {
                     $reject(new \RuntimeException('Unable to log in: ' . $data['Error']));
@@ -125,6 +131,10 @@ class Factory
 
                     return;
                 }
+
+                // otherwise reject if we receive an unexpected message
+                $reject(new \RuntimeException('Received unexpected "' . $type . '" message during login'));
+                $client->close();
             });
 
             // reject promise if client emits error

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -67,10 +67,77 @@ class Factory
         });
 
         // decorate client once probing is finished
-        return $promise->then(
+        $promise = $promise->then(
             function (DuplexStreamInterface $stream) use (&$probe) {
                 return new Client($stream, Protocol::createFromProbe($probe));
             }
         );
+
+        // automatic login if username/password is given as part of URI
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            $that = $this;
+            $promise = $promise->then(function (Client $client) use ($that, $parts) {
+                return $that->awaitLogin(
+                    $client,
+                    isset($parts['user']) ? urldecode($parts['user']) : '',
+                    isset($parts['pass']) ? urldecode($parts['pass']) : ''
+                );
+            });
+        }
+
+        return $promise;
+    }
+
+    /** @internal */
+    public function awaitLogin(Client $client, $user, $pass)
+    {
+        return new Promise\Promise(function ($resolve, $reject) use ($client, $user, $pass) {
+            // handle incoming response messages
+            $client->on('data', $handler = function ($data) use ($resolve, $reject, $client, $user, $pass, &$handler) {
+                $type = null;
+                if (is_array($data) && isset($data['MsgType'])) {
+                    $type = $data['MsgType'];
+                }
+
+                // continue to login if connection is initialized
+                if ($type === 'ClientInitAck') {
+                    if (!isset($data['Configured']) || !$data['Configured']) {
+                        $reject(new \RuntimeException('Unable to log in to unconfigured Quassel IRC core'));
+                        return $client->close();
+                    }
+
+                    $client->writeClientLogin($user, $pass);
+
+                    return;
+                }
+
+                // reject promise if login is rejected
+                if ($type === 'ClientLoginReject') {
+                    $reject(new \RuntimeException('Unable to log in: ' . $data['Error']));
+                    return $client->close();
+                }
+
+                // resolve promise if login is successful
+                if ($type === 'ClientLoginAck') {
+                    $client->removeListener('data', $handler);
+                    $handler = null;
+                    $resolve($client);
+
+                    return;
+                }
+            });
+
+            // reject promise if client emits error
+            $client->on('error', function ($error) use ($reject) {
+                $reject($error);
+            });
+
+            // reject promise if client closes while waiting for login
+            $client->on('close', function () use ($reject) {
+                $reject(new \RuntimeException('Unexpected close'));
+            });
+
+            $client->writeClientInit();
+        });
     }
 }

--- a/tests/FactoryIntegrationTest.php
+++ b/tests/FactoryIntegrationTest.php
@@ -1,0 +1,259 @@
+<?php
+
+use Clue\React\Block;
+use Clue\React\Quassel\Client;
+use Clue\React\Quassel\Factory;
+use React\EventLoop\Factory as LoopFactory;
+use React\Socket\Server;
+use React\Socket\ConnectionInterface;
+use Clue\React\Quassel\Io\Protocol;
+
+class FactoryIntegrationTest extends TestCase
+{
+    public function testCreateClientCreatesConnection()
+    {
+        $loop = LoopFactory::create();
+
+        $server = new Server(0, $loop);
+        $server->on('connection', $this->expectCallableOnce());
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient($uri);
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testCreateClientSendsProbeOverConnection()
+    {
+        $loop = LoopFactory::create();
+
+        $server = new Server(0, $loop);
+
+        $data = $this->expectCallableOnceWith("\x42\xb3\x3f\x00" . "\x00\x00\x00\x02" . "\x80\x00\x00\x01");
+        $server->on('connection', function (ConnectionInterface $conn) use ($data) {
+            $conn->on('data', $data);
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient($uri);
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public function testCreateClientResolvesIfServerRespondsWithProbeResponse()
+    {
+        $loop = LoopFactory::create();
+
+        $server = new Server(0, $loop);
+
+        $server->on('connection', function (ConnectionInterface $conn) {
+            $conn->on('data', function () use ($conn) {
+                $conn->write("\x00\x00\x00\x02");
+            });
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient($uri);
+
+        $client = Block\await($promise, $loop, 10.0);
+
+        $this->assertTrue($client instanceof Client);
+        $client->close();
+    }
+
+    public function testCreateClientCreatesSecondConnectionWithoutProbeIfConnectionClosesDuringProbe()
+    {
+        $loop = LoopFactory::create();
+        $server = new Server(0, $loop);
+
+        $once = $this->expectCallableOnce();
+        $server->on('connection', function (ConnectionInterface $conn) use ($once) {
+            $conn->on('data', function () use ($conn) {
+                $conn->close();
+            });
+            $conn->on('data', $once);
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient($uri);
+
+        Block\sleep(0.1, $loop);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testCreateClientRejectsIfServerRespondsWithInvalidData()
+    {
+        $loop = LoopFactory::create();
+        $server = new Server(0, $loop);
+
+        $server->on('connection', function (ConnectionInterface $conn) {
+            $conn->on('data', function () use ($conn) {
+                $conn->write('invalid');
+            });
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient($uri);
+
+        Block\await($promise, $loop, 10.0);
+    }
+
+    public function testCreateClientWithAuthSendsClientInitAfterProbe()
+    {
+        $loop = LoopFactory::create();
+        $server = new Server(0, $loop);
+
+        $data = $this->expectCallableOnceWith($this->callback(function ($packet) {
+            $data = FactoryIntegrationTest::decode($packet);
+
+            return (isset($data['MsgType']) && $data['MsgType'] === 'ClientInit');
+        }));
+
+        $server->on('connection', function (ConnectionInterface $conn) use ($data) {
+            $conn->on('data', function () use ($conn, $data) {
+                $conn->write("\x00\x00\x00\x02");
+                $conn->on('data', $data);
+            });
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient('user:pass@' . $uri);
+
+        Block\sleep(0.1, $loop);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testCreateClientWithAuthRejectsIfServerClosesAfterClientInit()
+    {
+        $loop = LoopFactory::create();
+        $server = new Server(0, $loop);
+
+        $server->on('connection', function (ConnectionInterface $conn) {
+            $conn->on('data', function () use ($conn) {
+                $conn->write("\x00\x00\x00\x02");
+                $conn->on('data', function () use ($conn) {
+                    $conn->close();
+                });
+            });
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient('user:pass@' . $uri);
+
+        Block\await($promise, $loop, 10.0);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testCreateClientWithAuthRejectsIfServerSendsInvalidTruncatedResponseAfterClientInit()
+    {
+        $loop = LoopFactory::create();
+        $server = new Server(0, $loop);
+
+        $server->on('connection', function (ConnectionInterface $conn) {
+            $conn->once('data', function () use ($conn) {
+                $conn->write("\x00\x00\x00\x02");
+                $conn->on('data', function () use ($conn) {
+                    $conn->end("\x00\x00");
+                });
+            });
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient('user:pass@' . $uri);
+
+        Block\await($promise, $loop, 10.0);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testCreateClientWithAuthRejectsIfServerSendsClientInitAckNotConfigured()
+    {
+        $loop = LoopFactory::create();
+        $server = new Server(0, $loop);
+
+        $server->on('connection', function (ConnectionInterface $conn) {
+            $conn->once('data', function () use ($conn) {
+                $conn->write("\x00\x00\x00\x02");
+                $conn->on('data', function () use ($conn) {
+                    // respond with not configured
+                    $conn->write(FactoryIntegrationTest::encode(array(
+                        'MsgType' => 'ClientInitAck',
+                        'Configured' => false
+                    )));
+                });
+            });
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient('user:pass@' . $uri);
+
+        Block\await($promise, $loop, 10.0);
+    }
+
+    public function testCreateClientWithAuthSendsClientLoginAfterClientInit()
+    {
+        $loop = LoopFactory::create();
+        $server = new Server(0, $loop);
+
+        // expect login packet
+        $data = $this->expectCallableOnceWith($this->callback(function ($packet) {
+            $protocol = Protocol::createFromProbe(0x02);
+            $data = $protocol->parseVariantPacket(substr($packet, 4));
+
+            return (isset($data['MsgType'], $data['User'], $data['Password']) && $data['MsgType'] === 'ClientLogin');
+        }));
+
+        $server->on('connection', function (ConnectionInterface $conn) use ($data) {
+            $conn->once('data', function () use ($conn, $data) {
+                $conn->write("\x00\x00\x00\x02");
+                $conn->once('data', function () use ($conn, $data) {
+                    // expect login next
+                    $conn->on('data', $data);
+
+                    // response with successful init
+                    $conn->write(FactoryIntegrationTest::encode(array(
+                        'MsgType' => 'ClientInitAck',
+                        'Configured' => true
+                    )));
+                });
+            });
+        });
+
+        $uri = str_replace('tcp://', '', $server->getAddress());
+        $factory = new Factory($loop);
+        $promise = $factory->createClient('user:pass@' . $uri);
+
+        Block\sleep(0.1, $loop);
+    }
+
+    public static function encode($data)
+    {
+        $protocol = Protocol::createFromProbe(0x02);
+        $packet = $protocol->serializeVariantPacket($data);
+
+        return pack('N', strlen($packet)) . $packet;
+    }
+
+    public static function decode($packet)
+    {
+        $protocol = Protocol::createFromProbe(0x02);
+
+        return $protocol->parseVariantPacket(substr($packet, 4));
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -35,7 +35,7 @@ class FactoryTest extends TestCase
     {
         $deferred = new Deferred();
         $this->connector->expects($this->once())->method('connect')->with($this->equalTo('example.com:1234'))->will($this->returnValue($deferred->promise()));
-        $this->factory->createClient('quassel://example.com:1234/ignored?ignored#ignored');
+        $this->factory->createClient('quassel://user:pass@example.com:1234/ignored?ignored#ignored');
     }
 
     public function testInvalidUriWillRejectWithoutConnecting()

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -180,6 +180,33 @@ class FunctionalTest extends TestCase
         return Block\await($promise, self::$loop, 10.0);
     }
 
+    public function testCreateClientWithAuthUrlReceivesSessionInit()
+    {
+        $factory = new Factory(self::$loop);
+
+        $url = rawurlencode(self::$username) . ':' . rawurlencode(self::$password) . '@' . self::$host;
+        $promise = $factory->createClient($url);
+        $client = Block\await($promise, self::$loop, 10.0);
+
+        $message = $this->awaitMessage($client);
+        $this->assertEquals('SessionInit', $message['MsgType']);
+
+        $client->close();
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testCreateClientWithInvalidAuthUrlRejects()
+    {
+        $factory = new Factory(self::$loop);
+
+        $url = rawurlencode(self::$username) . ':@' . self::$host;
+        $promise = $factory->createClient($url);
+
+        Block\await($promise, self::$loop, 10.0);
+    }
+
     private function awaitMessage(Client $client)
     {
         return Block\await(new Promise(function ($resolve, $reject) use ($client) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,18 +11,9 @@ class TestCase extends BaseTestCase
     protected function expectCallableOnce()
     {
         $mock = $this->createCallableMock();
-
-
-        if (func_num_args() > 0) {
-            $mock
-                ->expects($this->once())
-                ->method('__invoke')
-                ->with($this->equalTo(func_get_arg(0)));
-        } else {
-            $mock
-                ->expects($this->once())
-                ->method('__invoke');
-        }
+        $mock
+            ->expects($this->once())
+            ->method('__invoke');
 
         return $mock;
     }
@@ -30,11 +21,10 @@ class TestCase extends BaseTestCase
     protected function expectCallableOnceWith($value)
     {
         $mock = $this->createCallableMock();
-
         $mock
             ->expects($this->once())
             ->method('__invoke')
-            ->with($this->equalTo($value));
+            ->with($value);
 
         return $mock;
     }
@@ -49,23 +39,9 @@ class TestCase extends BaseTestCase
         return $mock;
     }
 
-    protected function expectCallableOnceParameter($type)
-    {
-        $mock = $this->createCallableMock();
-        $mock
-            ->expects($this->once())
-            ->method('__invoke')
-            ->with($this->isInstanceOf($type));
-
-        return $mock;
-    }
-
-    /**
-     * @link https://github.com/reactphp/react/blob/master/tests/React/Tests/Socket/TestCase.php (taken from reactphp/react)
-     */
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('CallableStub')->getMock();
+        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
     }
 
     protected function expectPromiseResolve($promise)
@@ -84,12 +60,5 @@ class TestCase extends BaseTestCase
         $promise->then($this->expectCallableNever(), $this->expectCallableOnce());
 
         return $promise;
-    }
-}
-
-class CallableStub
-{
-    public function __invoke()
-    {
     }
 }


### PR DESCRIPTION
Quassel supports password-based authentication. If you want to create a "normal"
client connection, you're recommended to pass the authentication details as part
of the URI. You can pass the password `h@llo` URL-encoded (percent-encoded)
as part of the URI like this:

```php
$factory->createClient('quassel://user:h%40llo@localhost')->then(
    function (Client $client) {
        // client sucessfully connected and authenticated
        $client->on('data', function ($data) {
            // next message to follow would be "SessionInit"
        });
    }
);
```

Note that if you do not pass the authentication details as part of the URI, then
this method will resolve with a "bare" `Client` right after connecting without
sending any application messages. This can be useful if you need full control
over the message flow, see the documentation for more details.