### PR TITLE
Automatically reply to heartbeat requests (ping) unless given "?pong=0"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ this method will resolve with a "bare" `Client` right after connecting without
 sending any application messages. This can be useful if you need full control
 over the message flow, see below for more details.
 
+Quassel uses "heartbeat" messages as a keep-alive mechanism to check the
+connection between Quassel core and Quassel client is still active. This project
+will automatically respond to each incoming "ping" (heartbeat request) with an
+appropriate "pong" (heartbeat response) message. If you do not want this and
+want to handle incoming heartbeat request messages yourself, you may pass the
+optional `?pong=0` parameter like this:
+
+```php
+$factory->createClient('quassel://localhost?pong=0');
+```
+
 >   This method uses Quassel IRC's probing mechanism for the correct protocol to
     use (newer "datastream" protocol or original "legacy" protocol).
     Protocol handling will be abstracted away for you, so you don't have to

--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -50,13 +50,6 @@ $factory->createClient($uri)->then(function (Client $client) use ($loop, $keywor
             return;
         }
 
-        // reply to heartbeat messages to avoid timing out
-        if (isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEAT) {
-            $client->writeHeartBeatReply($message[1]);
-
-            return;
-        }
-
         // chat message received
         if (isset($message[0]) && $message[0] === Protocol::REQUEST_RPCCALL && $message[1] === '2displayMsg(Message)') {
             $data = $message[2];

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -50,13 +50,6 @@ $factory->createClient($uri)->then(function (Client $client) use ($loop) {
             return;
         }
 
-        // reply to heartbeat messages to avoid timing out
-        if (isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEAT) {
-            $client->writeHeartBeatReply($message[1]);
-
-            return;
-        }
-
         // network information received, remember nick used on this network
         if (isset($message[0]) && $message[0] === Protocol::REQUEST_INITDATA && $message[1] === 'Network') {
             $nicks[$message[2]] = $message[3]['myNick'];

--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -62,16 +62,8 @@ $factory->createClient($uri)->then(function (Client $client) use ($loop) {
             $type = $message[0];
         }
 
-        // reply to heartbeat messages to avoid timing out
-        if ($type === Protocol::REQUEST_HEARTBEAT) {
-            //var_dump('heartbeat', $message[1]);
-            $client->writeHeartBeatReply($message[1]);
-
-            return;
-        }
-
-        // ignore heartbeat reply messages to our heartbeat requests
-        if ($type === Protocol::REQUEST_HEARTBEATREPLY) {
+        // ignore heartbeat requests and reply messages to our heartbeat requests
+        if ($type === Protocol::REQUEST_HEARTBEAT || $type === Protocol::REQUEST_HEARTBEATREPLY) {
             return;
         }
 

--- a/examples/11-debug.php
+++ b/examples/11-debug.php
@@ -108,14 +108,6 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
 
             return;
         }
-
-        // reply to heartbeat messages to avoid timing out
-        if (isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEAT) {
-            //var_dump('heartbeat', $message[1]);
-            $client->writeHeartBeatReply($message[1]);
-
-            return;
-        }
     });
 
     $client->on('error', 'printf');


### PR DESCRIPTION
Quassel uses "heartbeat" messages as a keep-alive mechanism to check the
connection between Quassel core and Quassel client is still active. This project
will automatically respond to each incoming "ping" (heartbeat request) with an
appropriate "pong" (heartbeat response) message. If you do not want this and
want to handle incoming heartbeat request messages yourself, you may pass the
optional `?pong=0` parameter like this:

```php
$factory->createClient('quassel://localhost?pong=0');
```

This is technically a BC break because consumers of this package would need to handle this manually previously and switching to this new behavior means that this consumer code may not send duplicate heartbeat replies. In practical terms, adjust this is rather straight-forward and this makes consuming this library easier for most common use cases.

Builds on top of #36 and its much improved test suite