### PR TITLE
 Automatically send heartbeat requests (ping) unless given "?ping=0" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,14 @@ This automatic "pong" mechanism allows the Quassel core to detect the connection
 to the client is still active. However, it does not allow the client to detect
 if the connection to the Quassel core is still active. Because of this, this
 project will automatically send a "ping" (heartbeat request) message to the
-Quassel core if it did not receive any messages for 60s by default. You can pass
-the `?ping=120.0` parameter to change this default interval. The Quassel core
-uses a configurable ping interval of 30s by default and also sends all IRC
-network state changes to the client, so this mechanism should only really kick
-in if the connection looks dead. If you do not want this and want to handle
-outgoing heartbeat request messages yourself, you may pass the optional `?ping=0`
-parameter like this:
+Quassel core if it did not receive any messages for 60s by default. If no
+message has been received after waiting for another period, the connection is
+assumed to be dead and will be closed. You can pass the `?ping=120.0` parameter
+to change this default interval. The Quassel core uses a configurable ping
+interval of 30s by default and also sends all IRC network state changes to the
+client, so this mechanism should only really kick in if the connection looks
+dead. If you do not want this and want to handle outgoing heartbeat request
+messages yourself, you may pass the optional `?ping=0` parameter like this:
 
 ```php
 $factory->createClient('quassel://localhost?ping=0');

--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ optional `?pong=0` parameter like this:
 $factory->createClient('quassel://localhost?pong=0');
 ```
 
+This automatic "pong" mechanism allows the Quassel core to detect the connection
+to the client is still active. However, it does not allow the client to detect
+if the connection to the Quassel core is still active. Because of this, this
+project will automatically send a "ping" (heartbeat request) message to the
+Quassel core if it did not receive any messages for 60s by default. You can pass
+the `?ping=120.0` parameter to change this default interval. The Quassel core
+uses a configurable ping interval of 30s by default and also sends all IRC
+network state changes to the client, so this mechanism should only really kick
+in if the connection looks dead. If you do not want this and want to handle
+outgoing heartbeat request messages yourself, you may pass the optional `?ping=0`
+parameter like this:
+
+```php
+$factory->createClient('quassel://localhost?ping=0');
+```
+
 >   This method uses Quassel IRC's probing mechanism for the correct protocol to
     use (newer "datastream" protocol or original "legacy" protocol).
     Protocol handling will be abstracted away for you, so you don't have to

--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -29,23 +29,13 @@ $factory = new Factory($loop);
 
 $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
-$factory->createClient($uri)->then(function (Client $client) use ($loop, $keyword) {
+$factory->createClient($uri)->then(function (Client $client) use ($keyword) {
     var_dump('CONNECTED');
 
-    $client->on('data', function ($message) use ($client, $keyword, $loop) {
+    $client->on('data', function ($message) use ($client, $keyword) {
         // session initialized
         if (isset($message['MsgType']) && $message['MsgType']=== 'SessionInit') {
             var_dump('session initialized, now waiting for incoming messages');
-
-            // send heartbeat message every 30s to check dropped connection
-            $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
-                $client->writeHeartBeatRequest();
-            });
-
-            // stop heartbeat timer once connection closes
-            $client->on('close', function () use ($loop, $timer) {
-                $loop->cancelTimer($timer);
-            });
 
             return;
         }

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -22,12 +22,12 @@ $factory = new Factory($loop);
 
 $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
-$factory->createClient($uri)->then(function (Client $client) use ($loop) {
+$factory->createClient($uri)->then(function (Client $client) {
     var_dump('CONNECTED');
 
     $nicks = array();
 
-    $client->on('data', function ($message) use ($client, &$nicks, $loop) {
+    $client->on('data', function ($message) use ($client, &$nicks) {
         // session initialized => initialize all networks
         if (isset($message['MsgType']) && $message['MsgType'] === 'SessionInit') {
             var_dump('session initialized, now waiting for incoming messages');
@@ -36,16 +36,6 @@ $factory->createClient($uri)->then(function (Client $client) use ($loop) {
                 var_dump('requesting Network for ' . $nid . ', this may take a few seconds');
                 $client->writeInitRequest("Network", $nid);
             }
-
-            // send heartbeat message every 30s to check dropped connection
-            $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
-                $client->writeHeartBeatRequest();
-            });
-
-            // stop heartbeat timer once connection closes
-            $client->on('close', function () use ($loop, $timer) {
-                $loop->cancelTimer($timer);
-            });
 
             return;
         }

--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -22,10 +22,10 @@ $factory = new Factory($loop);
 
 $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
-$factory->createClient($uri)->then(function (Client $client) use ($loop) {
+$factory->createClient($uri)->then(function (Client $client) {
     var_dump('CONNECTED');
 
-    $client->on('data', function ($message) use ($client, $loop) {
+    $client->on('data', function ($message) use ($client) {
         // session initialized => initialize all networks and buffers
         if (isset($message['MsgType']) && $message['MsgType'] === 'SessionInit') {
             var_dump('session initialized');
@@ -41,16 +41,6 @@ $factory->createClient($uri)->then(function (Client $client) use ($loop) {
                     $client->writeInitRequest('IrcChannel', $buffer['network'] . '/' . $buffer['id']);
                 }
             }
-
-            // send heartbeat message every 30s to check dropped connection
-            $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
-                $client->writeHeartBeatRequest();
-            });
-
-            // stop heartbeat timer once connection closes
-            $client->on('close', function () use ($loop, $timer) {
-                $loop->cancelTimer($timer);
-            });
 
             var_dump('initialization completed, now waiting for incoming messages (assuming core receives any)');
 

--- a/examples/11-debug.php
+++ b/examples/11-debug.php
@@ -22,11 +22,11 @@ $loop = \React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 
 echo '[1/5] Connecting' . PHP_EOL;
-$factory->createClient($host)->then(function (Client $client) use ($loop, $user) {
+$factory->createClient($host)->then(function (Client $client) use ($user) {
     echo '[2/5] Connected, now initializing' . PHP_EOL;
     $client->writeClientInit();
 
-    $client->on('data', function ($message) use ($client, $user, $loop) {
+    $client->on('data', function ($message) use ($client, $user) {
         if (isset($message[3]['IrcUsersAndChannels'])) {
             // print network information except for huge users/channels list
             $debug = $message;
@@ -95,16 +95,6 @@ $factory->createClient($host)->then(function (Client $client) use ($loop, $user)
                     $client->writeInitRequest('IrcChannel', $buffer['network'] . '/' . $buffer['id']);
                 }
             }
-
-            // send heartbeat message every 30s to check dropped connection
-            $timer = $loop->addPeriodicTimer(30.0, function () use ($client) {
-                $client->writeHeartBeatRequest();
-            });
-
-            // stop heartbeat timer once connection closes
-            $client->on('close', function () use ($loop, $timer) {
-                $loop->cancelTimer($timer);
-            });
 
             return;
         }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -90,12 +90,37 @@ class Factory
             });
         }
 
+        // automatically send ping requests and await pong replies unless "?ping=0" is given
         // automatically reply to incoming ping requests with a pong unless "?pong=0" is given
-        if (!isset($args['pong']) || $args['pong']) {
-            $promise = $promise->then(function (Client $client) {
-                $client->on('data', function ($message) use ($client) {
-                    if (isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEAT) {
+        $ping = (!isset($args['ping'])) ? 60 : (float)$args['ping'];
+        $pong = (!isset($args['pong']) || $args['pong']) ? true : false;
+        if ($ping !== 0.0 || $pong) {
+            $loop = $this->loop;
+            $promise = $promise->then(function (Client $client) use ($loop, $ping, $pong) {
+                $timer = null;
+                if ($ping !== 0.0) {
+                    // send heartbeat message every X seconds to check dropped connection
+                    $timer = $loop->addPeriodicTimer($ping, function () use ($client) {
+                        $client->writeHeartBeatRequest();
+                    });
+
+                    // stop heartbeat timer once connection closes
+                    $client->on('close', function () use ($loop, &$timer) {
+                        $loop->cancelTimer($timer);
+                        $timer = null;
+                    });
+                }
+
+                $client->on('data', function ($message) use ($client, $pong, &$timer, $loop) {
+                    // reply to incoming ping messages with pong
+                    if (isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEAT && $pong) {
                         $client->writeHeartBeatReply($message[1]);
+                    }
+
+                    // restart heartbeat timer once data comes in
+                    if ($timer !== null) {
+                        $loop->cancelTimer($timer);
+                        $timer = $loop->addPeriodicTimer($timer->getInterval(), $timer->getCallback());
                     }
                 });
 


### PR DESCRIPTION
The automatic "pong" mechanism allows the Quassel core to detect the connection
to the client is still active. However, it does not allow the client to detect
if the connection to the Quassel core is still active. Because of this, this
project will automatically send a "ping" (heartbeat request) message to the
Quassel core if it did not receive any messages for 60s by default. If no
message has been received after waiting for another period, the connection is
assumed to be dead and will be closed. You can pass the `?ping=120.0` parameter
to change this default interval. The Quassel core uses a configurable ping
interval of 30s by default and also sends all IRC network state changes to the
client, so this mechanism should only really kick in if the connection looks
dead. If you do not want this and want to handle outgoing heartbeat request
messages yourself, you may pass the optional `?ping=0` parameter like this:

```php
$factory->createClient('quassel://localhost?ping=0');
```

This is technically a BC break because consumers of this package would need to handle this manually previously and switching to this new behavior means that this consumer code may now send duplicate heartbeat requests. In practical terms, adjusting this is rather straight-forward and this makes consuming this library easier for most common use cases.

Builds on top of #38 