### PR TITLE
Fix writeBufferInput() to properly use BufferInfo

### DIFF
--- a/examples/11-debug.php
+++ b/examples/11-debug.php
@@ -3,6 +3,7 @@
 use Clue\React\Quassel\Factory;
 use Clue\React\Quassel\Client;
 use Clue\React\Quassel\Io\Protocol;
+use Clue\React\Quassel\Models\BufferInfo;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -90,9 +91,10 @@ $factory->createClient($host)->then(function (Client $client) use ($user) {
             }
 
             foreach ($message['SessionState']['BufferInfos'] as $buffer) {
-                if ($buffer['type'] === 2) { // type == 4 for user
-                    var_dump('requesting IrcChannel for ' . $buffer['name']);
-                    $client->writeInitRequest('IrcChannel', $buffer['network'] . '/' . $buffer['id']);
+                assert($buffer instanceof BufferInfo);
+                if ($buffer->getType() === BufferInfo::TYPE_CHANNEL) {
+                    var_dump('requesting IrcChannel for ' . $buffer->getName());
+                    $client->writeInitRequest('IrcChannel', $buffer->getNetworkId() . '/' . $buffer->getId());
                 }
             }
 

--- a/src/Io/Protocol.php
+++ b/src/Io/Protocol.php
@@ -90,12 +90,12 @@ abstract class Protocol
         );
 
         $this->userTypeWriter = array(
-            'BufferInfo' => function ($data, Writer $writer) {
-                $writer->writeUInt($data['id']);
-                $writer->writeUInt($data['network']);
-                $writer->writeUShort($data['type']);
-                $writer->writeUInt($data['group']);
-                $writer->writeQByteArray($data['name']);
+            'BufferInfo' => function (BufferInfo $buffer, Writer $writer) {
+                $writer->writeUInt($buffer->getId());
+                $writer->writeUInt($buffer->getNetworkId());
+                $writer->writeUShort($buffer->getType());
+                $writer->writeUInt($buffer->getGroupId());
+                $writer->writeQByteArray($buffer->getName());
             },
             'BufferId' => function ($data, Writer $writer) {
                 $writer->writeUInt($data);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Clue\React\Quassel\Client;
+use Clue\React\Quassel\Io\DatastreamProtocol;
 use Clue\React\Quassel\Io\Protocol;
+use Clue\React\Quassel\Models\BufferInfo;
 use React\Stream\ThroughStream;
 
 class ClientTest extends TestCase
@@ -191,6 +193,18 @@ class ClientTest extends TestCase
     {
         $this->expectWriteMap();
         $this->client->writeCoreSetupData('user', 'pass', 'PQSql', array('password' => 'test'));
+    }
+
+    public function testWriteBufferInputWritesToStreamOnce()
+    {
+        $this->protocol = new DatastreamProtocol();
+        $this->client = new Client($this->stream, $this->protocol, $this->splitter);
+
+        $this->stream->expects($this->once())->method('write');
+
+        $bufferInfo = new BufferInfo(1, 2, 3, 4, '#test');
+
+        $this->client->writeBufferInput($bufferInfo, 'Hello!');
     }
 
     public function testWriteHeartBeatReply()


### PR DESCRIPTION
This fixes a small oversight from #41 and adds some rudimentary smoke test at least.