### PR TITLE
Use public properties for `Message` and `BufferInfo` models

### DIFF
--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -46,10 +46,10 @@ $factory->createClient($uri)->then(function (Client $client) use ($keyword) {
             $in = $message[2];
             assert($in instanceof Message);
 
-            if (strpos($in->getContents(), $keyword) !== false) {
-                $client->writeBufferInput($in->getBufferInfo(), 'Hello from clue/quassel-react :-)');
+            if (strpos($in->contents, $keyword) !== false) {
+                $client->writeBufferInput($in->bufferInfo, 'Hello from clue/quassel-react :-)');
 
-                echo date('Y-m-d H:i:s') . ' Replied to ' . $in->getBufferInfo()->getName() . '/' . explode('!', $in->getSender())[0] . ': "' . $in->getContents() . '"' . PHP_EOL;
+                echo date('Y-m-d H:i:s') . ' Replied to ' . $in->bufferInfo->name . '/' . explode('!', $in->sender)[0] . ': "' . $in->contents . '"' . PHP_EOL;
             }
         }
     });

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -72,22 +72,22 @@ $factory->createClient($uri)->then(function (Client $client) {
 
             // we may be connected to multiple networks with different nicks
             // find correct nick for current network
-            $nick = isset($nicks[$in->getBufferInfo()->getNetworkId()]) ? $nicks[$in->getBufferInfo()->getNetworkId()] : null;
+            $nick = isset($nicks[$in->bufferInfo->networkId]) ? $nicks[$in->bufferInfo->networkId] : null;
 
             // received "nick: ping" in any buffer/channel
-            if ($nick !== null && strtolower($in->getContents()) === ($nick . ': ping')) {
-                $reply = explode('!', $in->getSender())[0] . ': pong :-)';
+            if ($nick !== null && strtolower($in->contents) === ($nick . ': ping')) {
+                $reply = explode('!', $in->sender)[0] . ': pong :-)';
             }
 
             // received "ping" in direct query buffer (user to user)
-            if (strtolower($in->getContents()) === 'ping' && $in->getBufferInfo()->getType() === BufferInfo::TYPE_QUERY) {
+            if (strtolower($in->contents) === 'ping' && $in->bufferInfo->type === BufferInfo::TYPE_QUERY) {
                 $reply = 'pong :-)';
             }
 
             if ($reply !== null) {
-                $client->writeBufferInput($in->getBufferInfo(), $reply);
+                $client->writeBufferInput($in->bufferInfo, $reply);
 
-                echo date('Y-m-d H:i:s') . ' Replied to ' . $in->getBufferInfo()->getName() . '/' . explode('!', $in->getSender())[0] . ': "' . $in->getContents() . '"' . PHP_EOL;
+                echo date('Y-m-d H:i:s') . ' Replied to ' . $in->bufferInfo->name . '/' . explode('!', $in->sender)[0] . ': "' . $in->contents . '"' . PHP_EOL;
             }
         }
     });

--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -39,9 +39,9 @@ $factory->createClient($uri)->then(function (Client $client) {
 
             foreach ($message['SessionState']['BufferInfos'] as $buffer) {
                 assert($buffer instanceof BufferInfo);
-                if ($buffer->getType() === BufferInfo::TYPE_CHANNEL) {
-                    var_dump('requesting IrcChannel for ' . $buffer->getName());
-                    $client->writeInitRequest('IrcChannel', $buffer->getNetworkId() . '/' . $buffer->getId());
+                if ($buffer->type === BufferInfo::TYPE_CHANNEL) {
+                    var_dump('requesting IrcChannel for ' . $buffer->name);
+                    $client->writeInitRequest('IrcChannel', $buffer->networkId . '/' . $buffer->id);
                 }
             }
 
@@ -63,7 +63,7 @@ $factory->createClient($uri)->then(function (Client $client) {
         if ($type === Protocol::REQUEST_RPCCALL && $message[1] === '2displayMsg(Message)') {
             $in = $message[2];
             assert($in instanceof Message);
-            echo date(DATE_ISO8601, $in->getTimestamp()) . ' in ' . $in->getBufferInfo()->getName() . ' by ' . explode('!', $in->getSender())[0] . ': ' . $in->getContents() . PHP_EOL;
+            echo date(DATE_ISO8601, $in->timestamp) . ' in ' . $in->bufferInfo->name . ' by ' . explode('!', $in->sender)[0] . ': ' . $in->contents . PHP_EOL;
 
             return;
         }

--- a/examples/05-backlog.php
+++ b/examples/05-backlog.php
@@ -34,16 +34,16 @@ $factory->createClient($uri)->then(function (Client $client) use ($channel) {
             $id = null;
             foreach ($message['SessionState']['BufferInfos'] as $buffer) {
                 assert($buffer instanceof BufferInfo);
-                $combined = $buffer->getNetworkId() . '/' . $buffer->getName();
-                if (($channel !== '' && $channel === $buffer->getName()) || $channel === (string)$buffer->getId() || $channel === $combined) {
-                    $id = $buffer->getId();
+                $combined = $buffer->networkId . '/' . $buffer->name;
+                if (($channel !== '' && $channel === $buffer->name) || $channel === (string)$buffer->id || $channel === $combined) {
+                    $id = $buffer->id;
                 }
             }
 
             // list all channels if channel could not be found
             if ($id === null && $channel !== '') {
                 echo 'Error: Could not find the given channel, see full list: ' . PHP_EOL;
-                var_dump($message['SessionState']['BufferInfos']) . PHP_EOL;
+                var_dump($message['SessionState']['BufferInfos']);
                 return $client->close();
             }
 
@@ -66,11 +66,11 @@ $factory->createClient($uri)->then(function (Client $client) use ($channel) {
 
                 echo json_encode(
                     array(
-                        'id' => $in->getId(),
-                        'date' => date(\DATE_ATOM, $in->getTimestamp()),
-                        'channel' => $in->getBufferInfo()->getName(),
-                        'sender' => explode('!', $in->getSender())[0],
-                        'contents' => $in->getContents()
+                        'id' => $in->id,
+                        'date' => date(\DATE_ATOM, $in->timestamp),
+                        'channel' => $in->bufferInfo->name,
+                        'sender' => explode('!', $in->sender)[0],
+                        'contents' => $in->contents
                     ),
                     JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE
                 ) . PHP_EOL;

--- a/examples/11-debug.php
+++ b/examples/11-debug.php
@@ -92,9 +92,9 @@ $factory->createClient($host)->then(function (Client $client) use ($user) {
 
             foreach ($message['SessionState']['BufferInfos'] as $buffer) {
                 assert($buffer instanceof BufferInfo);
-                if ($buffer->getType() === BufferInfo::TYPE_CHANNEL) {
-                    var_dump('requesting IrcChannel for ' . $buffer->getName());
-                    $client->writeInitRequest('IrcChannel', $buffer->getNetworkId() . '/' . $buffer->getId());
+                if ($buffer->type === BufferInfo::TYPE_CHANNEL) {
+                    var_dump('requesting IrcChannel for ' . $buffer->name);
+                    $client->writeInitRequest('IrcChannel', $buffer->networkId . '/' . $buffer->id);
                 }
             }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -227,7 +227,7 @@ class Client extends EventEmitter implements DuplexStreamInterface
      * in this array and pass this to this method as `$messageIdLast`.
      *
      * ```php
-     * $oldest = end($messages)->getId();
+     * $oldest = end($messages)->id;
      * $client->writeBufferRequestBacklog($id, -1, $oldest, 20, 0);
      * ```
      *
@@ -240,7 +240,7 @@ class Client extends EventEmitter implements DuplexStreamInterface
      * will contain the given message ID as the only entry.
      *
      * ```php
-     * $newest = reset($messages)->getId();
+     * $newest = reset($messages)->id;
      * $client->writeBufferRequestBacklog($id, $newest, -1, 20, 0);
      * ```
      *

--- a/src/Io/Protocol.php
+++ b/src/Io/Protocol.php
@@ -91,11 +91,11 @@ abstract class Protocol
 
         $this->userTypeWriter = array(
             'BufferInfo' => function (BufferInfo $buffer, Writer $writer) {
-                $writer->writeUInt($buffer->getId());
-                $writer->writeUInt($buffer->getNetworkId());
-                $writer->writeUShort($buffer->getType());
-                $writer->writeUInt($buffer->getGroupId());
-                $writer->writeQByteArray($buffer->getName());
+                $writer->writeUInt($buffer->id);
+                $writer->writeUInt($buffer->networkId);
+                $writer->writeUShort($buffer->type);
+                $writer->writeUInt($buffer->groupId);
+                $writer->writeQByteArray($buffer->name);
             },
             'BufferId' => function ($data, Writer $writer) {
                 $writer->writeUInt($data);

--- a/src/Models/BufferInfo.php
+++ b/src/Models/BufferInfo.php
@@ -11,11 +11,30 @@ class BufferInfo
     const TYPE_QUERY = 0x04;
     const TYPE_GROUP = 0x08;
 
-    private $id;
-    private $networkId;
-    private $type;
-    private $groupId;
-    private $name;
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var int
+     */
+    public $networkId;
+
+    /**
+     * @var int single type constant, see self::TYPE_*
+     */
+    public $type;
+
+    /**
+     * @var int
+     */
+    public $groupId;
+
+    /**
+     * @var string buffer/channel name `#channel` or `user` or empty string
+     */
+    public $name;
 
     /**
      * [Internal] Instantiation is handled internally and should not be called manually.
@@ -34,45 +53,5 @@ class BufferInfo
         $this->type = $type;
         $this->groupId = $groupId;
         $this->name = $name;
-    }
-
-    /**
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
-     * @return int
-     */
-    public function getNetworkId()
-    {
-        return $this->networkId;
-    }
-
-    /**
-     * @return int single type constant, see self::TYPE_*
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * @return int
-     */
-    public function getGroupId()
-    {
-        return $this->groupId;
-    }
-
-    /**
-     * @return string buffer/channel name `#channel` or `user` or empty string
-     */
-    public function getName()
-    {
-        return $this->name;
     }
 }

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -33,13 +33,40 @@ class Message
     const FLAG_STATUS_MESSAGE = 0x10;
     const FLAG_BACKLOG = 0x80;
 
-    private $id;
-    private $timestamp;
-    private $type;
-    private $flags;
-    private $bufferInfo;
-    private $sender;
-    private $contents;
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var int UNIX timestamp
+     */
+    public $timestamp;
+
+    /**
+     * @var int single type constant, see self::TYPE_* constants
+     */
+    public $type;
+
+    /**
+     * @var int bitmask of flag constants, see self::FLAG_* constants
+     */
+    public $flags;
+
+    /**
+     * @var BufferInfo reference to the buffer/channel this message was received in
+     */
+    public $bufferInfo;
+
+    /**
+     * @var string `nick!user@host` or just host or empty string depending on type/flags
+     */
+    public $sender;
+
+    /**
+     * @var string message contents contains the chat message or info which may be empty depending on type
+     */
+    public $contents;
 
     /**
      * [Internal] Instantiation is handled internally and should not be called manually.
@@ -62,62 +89,5 @@ class Message
         $this->bufferInfo = $bufferInfo;
         $this->sender = $sender;
         $this->contents = $contents;
-    }
-
-    /**
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
-     * @return int UNIX timestamp
-     */
-    public function getTimestamp()
-    {
-        return $this->timestamp;
-    }
-
-    /**
-     * @return int single type constant, see self::TYPE_* constants
-     */
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    /**
-     * @return int bitmask of flag constants, see self::FLAG_* constants
-     */
-    public function getFlags()
-    {
-        return $this->flags;
-    }
-
-    /**
-     * @return BufferInfo reference to the buffer/channel this message was received in
-     */
-    public function getBufferInfo()
-    {
-        return $this->bufferInfo;
-    }
-
-    /**
-     * @return string `nick!user@host` or just host or empty string depending on type/flags
-     * @see self::getSenderNick()
-     */
-    public function getSender()
-    {
-        return $this->sender;
-    }
-
-    /**
-     * @return string message contents contains the chat message or info which may be empty depending on type
-     */
-    public function getContents()
-    {
-        return $this->contents;
     }
 }

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -217,7 +217,7 @@ class FunctionalTest extends TestCase
 
         // fetch newest messages for this buffer
         $this->assertTrue($buffer instanceof BufferInfo);
-        $client->writeBufferRequestBacklog($buffer->getId(), -1, -1, $maximum = 2, 0);
+        $client->writeBufferRequestBacklog($buffer->id, -1, -1, $maximum = 2, 0);
 
         $received = $this->awaitMessage($client);
         $this->assertTrue(isset($received[0]));
@@ -237,7 +237,7 @@ class FunctionalTest extends TestCase
 
         // poll for newer messages in all channels
         $this->assertTrue($newest instanceof Message);
-        $client->writeBufferRequestBacklogAll($newest->getId(), -1, $maximum, 0);
+        $client->writeBufferRequestBacklogAll($newest->id, -1, $maximum, 0);
 
         $received = $this->awaitMessage($client);
         $this->assertTrue(isset($received[0]));

--- a/tests/Models/BufferInfoTest.php
+++ b/tests/Models/BufferInfoTest.php
@@ -8,21 +8,21 @@ class BufferInfoTest extends TestCase
     {
         $model = new BufferInfo(1, 3, BufferInfo::TYPE_CHANNEL, 0, '#reactphp');
 
-        $this->assertSame(1, $model->getId());
-        $this->assertSame(3, $model->getNetworkId());
-        $this->assertSame(BufferInfo::TYPE_CHANNEL, $model->getType());
-        $this->assertSame(0, $model->getGroupId());
-        $this->assertSame('#reactphp', $model->getName());
+        $this->assertSame(1, $model->id);
+        $this->assertSame(3, $model->networkId);
+        $this->assertSame(BufferInfo::TYPE_CHANNEL, $model->type);
+        $this->assertSame(0, $model->groupId);
+        $this->assertSame('#reactphp', $model->name);
     }
 
     public function testBufferInfoForUserQuery()
     {
         $model = new BufferInfo(2, 1, BufferInfo::TYPE_QUERY, 0, 'another_clue');
 
-        $this->assertSame(2, $model->getId());
-        $this->assertSame(1, $model->getNetworkId());
-        $this->assertSame(BufferInfo::TYPE_QUERY, $model->getType());
-        $this->assertSame(0, $model->getGroupId());
-        $this->assertSame('another_clue', $model->getName());
+        $this->assertSame(2, $model->id);
+        $this->assertSame(1, $model->networkId);
+        $this->assertSame(BufferInfo::TYPE_QUERY, $model->type);
+        $this->assertSame(0, $model->groupId);
+        $this->assertSame('another_clue', $model->name);
     }
 }

--- a/tests/Models/MessageTest.php
+++ b/tests/Models/MessageTest.php
@@ -17,13 +17,13 @@ class MessageTest extends TestCase
             'Hello world!'
         );
 
-        $this->assertSame(1000, $message->getId());
-        $this->assertSame(1528039705, $message->getTimestamp());
-        $this->assertSame(Message::TYPE_PLAIN, $message->getType());
-        $this->assertSame(Message::FLAG_NONE, $message->getFlags());
-        $this->assertSame($buffer, $message->getBufferInfo());
-        $this->assertSame('another_clue!user@host', $message->getSender());
-        $this->assertSame('Hello world!', $message->getContents());
+        $this->assertSame(1000, $message->id);
+        $this->assertSame(1528039705, $message->timestamp);
+        $this->assertSame(Message::TYPE_PLAIN, $message->type);
+        $this->assertSame(Message::FLAG_NONE, $message->flags);
+        $this->assertSame($buffer, $message->bufferInfo);
+        $this->assertSame('another_clue!user@host', $message->sender);
+        $this->assertSame('Hello world!', $message->contents);
     }
 
     public function testJoinMessage()
@@ -39,12 +39,12 @@ class MessageTest extends TestCase
             '#reactphp'
         );
 
-        $this->assertSame(999, $message->getId());
-        $this->assertSame(1528039704, $message->getTimestamp());
-        $this->assertSame(Message::TYPE_JOIN, $message->getType());
-        $this->assertSame(Message::FLAG_NONE, $message->getFlags());
-        $this->assertSame($buffer, $message->getBufferInfo());
-        $this->assertSame('another_clue!user@host', $message->getSender());
-        $this->assertSame('#reactphp', $message->getContents());
+        $this->assertSame(999, $message->id);
+        $this->assertSame(1528039704, $message->timestamp);
+        $this->assertSame(Message::TYPE_JOIN, $message->type);
+        $this->assertSame(Message::FLAG_NONE, $message->flags);
+        $this->assertSame($buffer, $message->bufferInfo);
+        $this->assertSame('another_clue!user@host', $message->sender);
+        $this->assertSame('#reactphp', $message->contents);
     }
 }


### PR DESCRIPTION
This helps making the existing interfaces more consistent and also means
automatic JSON serialization for the examples now works again.

For consistency reasons, all other messages should be changed to using
classes with public properties instead of using associate arrays in a
follow-up PR.

Builds on top of #41 