### PR TITLE
Represent all map structures as stdClass objects instead of assoc arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Incoming events will be forwarded to registered event handler callbacks:
 
 ```php
 $client->on('data', function ($data) {
-    // process an incoming message (raw message array)
+    // process an incoming message (raw message object or array)
     var_dump($data);
 });
 
@@ -216,7 +216,7 @@ There are only few noticable exceptions to this rule:
 
 *   Incoming buffers/channels and chat messages use complex data models, so they
     are represented by `BufferInfo` and `Message` respectively. All other data
-    types use plain structured data, so you can access it's array-based
+    types use plain structured data, so you can access its object-based
     structure very similar to a JSON-like data structure.
 *   The legacy protocol uses plain times for heartbeat messages while the newer
     datastream protocol uses `DateTime` objects.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
     	"php": ">=5.3",
-        "clue/qdatastream": "^0.7.2",
+        "clue/qdatastream": "^0.8",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "~2.0|~1.1",
         "react/socket": "^1.0 || ^0.8 || ^0.7",

--- a/examples/01-channels.php
+++ b/examples/01-channels.php
@@ -29,10 +29,10 @@ $factory->createClient($uri)->then(function (Client $client) {
 
     $client->on('data', function ($message) use ($client, &$await) {
         // session initialized => initialize all networks
-        if (isset($message['MsgType']) && $message['MsgType'] === 'SessionInit') {
+        if (isset($message->MsgType) && $message->MsgType === 'SessionInit') {
             var_dump('session initialized');
 
-            foreach ($message['SessionState']['NetworkIds'] as $nid) {
+            foreach ($message->SessionState->NetworkIds as $nid) {
                 var_dump('requesting Network for ' . $nid . ', this may take a few seconds');
                 $client->writeInitRequest("Network", $nid);
 
@@ -52,12 +52,12 @@ $factory->createClient($uri)->then(function (Client $client) {
         // network information received
         if (isset($message[0]) && $message[0] === Protocol::REQUEST_INITDATA && $message[1] === 'Network') {
             // print network information except for huge users/channels list
-            $info = $message[3];
-            unset($info['IrcUsersAndChannels']);
+            $info = clone $message[3];
+            unset($info->IrcUsersAndChannels);
             echo json_encode($info, JSON_PRETTY_PRINT) . PHP_EOL;
 
             // print names of all known channels on this network
-            foreach ($message[3]['IrcUsersAndChannels']['Channels']['name'] as $name) {
+            foreach ($message[3]->IrcUsersAndChannels->Channels->name as $name) {
                 echo $name . PHP_EOL;
             }
 

--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -35,7 +35,7 @@ $factory->createClient($uri)->then(function (Client $client) use ($keyword) {
 
     $client->on('data', function ($message) use ($client, $keyword) {
         // session initialized
-        if (isset($message['MsgType']) && $message['MsgType']=== 'SessionInit') {
+        if (isset($message->MsgType) && $message->MsgType === 'SessionInit') {
             var_dump('session initialized, now waiting for incoming messages');
 
             return;

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -31,10 +31,10 @@ $factory->createClient($uri)->then(function (Client $client) {
 
     $client->on('data', function ($message) use ($client, &$nicks) {
         // session initialized => initialize all networks
-        if (isset($message['MsgType']) && $message['MsgType'] === 'SessionInit') {
+        if (isset($message->MsgType) && $message->MsgType === 'SessionInit') {
             var_dump('session initialized, now waiting for incoming messages');
 
-            foreach ($message['SessionState']['NetworkIds'] as $nid) {
+            foreach ($message->SessionState->NetworkIds as $nid) {
                 var_dump('requesting Network for ' . $nid . ', this may take a few seconds');
                 $client->writeInitRequest("Network", $nid);
             }
@@ -44,9 +44,9 @@ $factory->createClient($uri)->then(function (Client $client) {
 
         // network information received, remember nick used on this network
         if (isset($message[0]) && $message[0] === Protocol::REQUEST_INITDATA && $message[1] === 'Network') {
-            $nicks[$message[2]] = $message[3]['myNick'];
+            $nicks[$message[2]] = $message[3]->myNick;
 
-            echo 'Network ' . $message[2] .' nick: ' . $message[3]['myNick'] . PHP_EOL;
+            echo 'Network ' . $message[2] .' nick: ' . $message[3]->myNick . PHP_EOL;
 
             return;
         }

--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -29,15 +29,15 @@ $factory->createClient($uri)->then(function (Client $client) {
 
     $client->on('data', function ($message) use ($client) {
         // session initialized => initialize all networks and buffers
-        if (isset($message['MsgType']) && $message['MsgType'] === 'SessionInit') {
+        if (isset($message->MsgType) && $message->MsgType === 'SessionInit') {
             var_dump('session initialized');
 
-            foreach ($message['SessionState']['NetworkIds'] as $nid) {
+            foreach ($message->SessionState->NetworkIds as $nid) {
                 var_dump('requesting Network for ' . $nid . ', this may take a few seconds');
                 $client->writeInitRequest("Network", $nid);
             }
 
-            foreach ($message['SessionState']['BufferInfos'] as $buffer) {
+            foreach ($message->SessionState->BufferInfos as $buffer) {
                 assert($buffer instanceof BufferInfo);
                 if ($buffer->type === BufferInfo::TYPE_CHANNEL) {
                     var_dump('requesting IrcChannel for ' . $buffer->name);

--- a/examples/05-backlog.php
+++ b/examples/05-backlog.php
@@ -29,10 +29,10 @@ $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
 $factory->createClient($uri)->then(function (Client $client) use ($channel) {
     $client->on('data', function ($message) use ($client, $channel) {
-        if (isset($message['MsgType']) && $message['MsgType'] === 'SessionInit') {
+        if (isset($message->MsgType) && $message->MsgType === 'SessionInit') {
             // session initialized => search channel ID for given channel name
             $id = null;
-            foreach ($message['SessionState']['BufferInfos'] as $buffer) {
+            foreach ($message->SessionState->BufferInfos as $buffer) {
                 assert($buffer instanceof BufferInfo);
                 $combined = $buffer->networkId . '/' . $buffer->name;
                 if (($channel !== '' && $channel === $buffer->name) || $channel === (string)$buffer->id || $channel === $combined) {
@@ -43,7 +43,7 @@ $factory->createClient($uri)->then(function (Client $client) use ($channel) {
             // list all channels if channel could not be found
             if ($id === null && $channel !== '') {
                 echo 'Error: Could not find the given channel, see full list: ' . PHP_EOL;
-                var_dump($message['SessionState']['BufferInfos']);
+                var_dump($message->SessionState->BufferInfos);
                 return $client->close();
             }
 

--- a/src/Io/DatastreamProtocol.php
+++ b/src/Io/DatastreamProtocol.php
@@ -84,15 +84,15 @@ class DatastreamProtocol extends Protocol
      * converts the given list to a map
      *
      * @param mixed[]|array<mixed> $list
-     * @return mixed[]|array<mixed>
+     * @return \stdClass `map<string,mixed>`
      * @internal
      */
-    public function listToMap($list)
+    public function listToMap(array $list)
     {
         $map = array();
         for ($i = 0, $n = count($list); $i < $n; $i += 2) {
             $map[$list[$i]] = $list[$i + 1];
         }
-        return $map;
+        return (object)$map;
     }
 }

--- a/src/Io/LegacyProtocol.php
+++ b/src/Io/LegacyProtocol.php
@@ -39,16 +39,16 @@ class LegacyProtocol extends Protocol
 
         // ping requests will actually be sent as QTime which assumes UTC timezone
         // times will be returned with local timezone, so account for offset to UTC
-        if (isset($data[0]) && ($data[0] === self::REQUEST_HEARTBEAT || $data[0] === self::REQUEST_HEARTBEATREPLY)) {
+        if (is_array($data) && isset($data[0]) && ($data[0] === self::REQUEST_HEARTBEAT || $data[0] === self::REQUEST_HEARTBEATREPLY)) {
             $data[1]->modify($data[1]->getOffset() .  ' seconds');
         }
 
         // upcast legacy InitData for "Network" to newer datagram variant
         // https://github.com/quassel/quassel/commit/208ccb6d91ebb3c26a67c35c11411ba3ab27708a#diff-c3c5a4e63a0b757912ba28686747b040
-        if (isset($data[0]) && $data[0] === self::REQUEST_INITDATA && $data[1] === 'Network' && isset($data[3]['IrcUsersAndChannels'])) {
+        if (is_array($data) && isset($data[0]) && $data[0] === self::REQUEST_INITDATA && $data[1] === 'Network' && isset($data[3]->IrcUsersAndChannels)) {
             $new = array();
             // $type would be "users" and "channels"
-            foreach ($data[3]['IrcUsersAndChannels'] as $type => $all) {
+            foreach ($data[3]->IrcUsersAndChannels as $type => $all) {
                 $map = array();
 
                 // iterate over all users/channels
@@ -60,11 +60,11 @@ class LegacyProtocol extends Protocol
                 }
 
                 // store new map with uppercase Users/Channels
-                $new[ucfirst($type)] = $map;
+                $new[ucfirst($type)] = (object)$map;
             }
 
             // make sure new structure comes first
-            $data[3] = array('IrcUsersAndChannels' => $new) + $data[3];
+            $data[3] = (object)(array('IrcUsersAndChannels' => (object)$new) + (array)$data[3]);
         }
 
         return $data;

--- a/tests/FactoryIntegrationTest.php
+++ b/tests/FactoryIntegrationTest.php
@@ -113,7 +113,7 @@ class FactoryIntegrationTest extends TestCase
         $data = $this->expectCallableOnceWith($this->callback(function ($packet) {
             $data = FactoryIntegrationTest::decode($packet);
 
-            return (isset($data['MsgType']) && $data['MsgType'] === 'ClientInit');
+            return (isset($data->MsgType) && $data->MsgType === 'ClientInit');
         }));
 
         $server->on('connection', function (ConnectionInterface $conn) use ($data) {
@@ -274,7 +274,7 @@ class FactoryIntegrationTest extends TestCase
             $protocol = Protocol::createFromProbe(0x02);
             $data = $protocol->parseVariantPacket(substr($packet, 4));
 
-            return (isset($data['MsgType'], $data['User'], $data['Password']) && $data['MsgType'] === 'ClientLogin');
+            return (isset($data->MsgType, $data->User, $data->Password) && $data->MsgType === 'ClientLogin');
         }));
 
         $server->on('connection', function (ConnectionInterface $conn) use ($data) {

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -67,7 +67,7 @@ class FunctionalTest extends TestCase
         $client->writeClientInit();
 
         $message = $this->awaitMessage($client);
-        $this->assertEquals('ClientInitAck', $message['MsgType']);
+        $this->assertEquals('ClientInitAck', $message->MsgType);
 
         return $message;
     }
@@ -77,18 +77,18 @@ class FunctionalTest extends TestCase
      * @depends testWriteClientInit
      *
      * @param Client $client
-     * @param array  $message
+     * @param stdClass $message
      */
-    public function testWriteCoreSetupData(Client $client, $message)
+    public function testWriteCoreSetupData(Client $client, stdClass $message)
     {
-        if ($message['Configured']) {
+        if ($message->Configured) {
             $this->markTestSkipped('Given core already configured, can not set-up');
         }
 
         $client->writeCoreSetupData(self::$username, self::$password);
 
         $message = $this->awaitMessage($client);
-        $this->assertEquals('CoreSetupAck', $message['MsgType']);
+        $this->assertEquals('CoreSetupAck', $message->MsgType);
 
         return $message;
     }
@@ -98,17 +98,17 @@ class FunctionalTest extends TestCase
      * @depends testWriteClientInit
      *
      * @param Client $client
-     * @param array  $message
+     * @param stdClass $message
      */
-    public function testWriteClientLogin(Client $client, $message)
+    public function testWriteClientLogin(Client $client, stdClass $message)
     {
         $client->writeClientLogin(self::$username, self::$password);
 
         $message = $this->awaitMessage($client);
-        $this->assertEquals('ClientLoginAck', $message['MsgType']);
+        $this->assertEquals('ClientLoginAck', $message->MsgType);
 
         $message = $this->awaitMessage($client);
-        $this->assertEquals('SessionInit', $message['MsgType']);
+        $this->assertEquals('SessionInit', $message->MsgType);
 
         return $message;
     }
@@ -125,7 +125,7 @@ class FunctionalTest extends TestCase
 
         $promise = new Promise(function ($resolve) use ($client) {
             $callback = function ($message) use ($resolve, &$callback, $client) {
-                if (isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEATREPLY) {
+                if (is_array($message) && isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEATREPLY) {
                     $client->removeListener('data', $callback);
                     $resolve($message[1]);
                 }
@@ -150,7 +150,7 @@ class FunctionalTest extends TestCase
     {
         $promise = new Promise(function ($resolve) use ($client) {
             $callback = function ($message) use ($resolve, &$callback, $client) {
-                if (isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEATREPLY) {
+                if (is_array($message) && isset($message[0]) && $message[0] === Protocol::REQUEST_HEARTBEATREPLY) {
                     $client->removeListener('data', $callback);
                     $resolve($message[1]);
                 }
@@ -191,7 +191,7 @@ class FunctionalTest extends TestCase
         $client = Block\await($promise, self::$loop, 10.0);
 
         $message = $this->awaitMessage($client);
-        $this->assertEquals('SessionInit', $message['MsgType']);
+        $this->assertEquals('SessionInit', $message->MsgType);
 
         $client->close();
     }
@@ -206,10 +206,10 @@ class FunctionalTest extends TestCase
         /* @var $client Client */
 
         $message = $this->awaitMessage($client);
-        $this->assertEquals('SessionInit', $message['MsgType']);
+        $this->assertEquals('SessionInit', $message->MsgType);
 
         // try to pick first buffer
-        $buffer = reset($message['SessionState']['BufferInfos']);
+        $buffer = reset($message->SessionState->BufferInfos);
         if ($buffer === false) {
             $client->close();
             $this->markTestSkipped('Empty quassel core with no buffers?');

--- a/tests/Io/AbstractProtocolTest.php
+++ b/tests/Io/AbstractProtocolTest.php
@@ -22,7 +22,7 @@ abstract class AbstractProtocolTest extends TestCase
 
         $packet = $this->protocol->serializeVariantPacket($in);
 
-        $this->assertEquals($in, $this->protocol->parseVariantPacket($packet));
+        $this->assertEquals($in, (array)$this->protocol->parseVariantPacket($packet));
     }
 
     public function testHeartBeatWithCorrectTimeZoneAndMillisecondAccuracy()

--- a/tests/Io/DatastreamProtocolTest.php
+++ b/tests/Io/DatastreamProtocolTest.php
@@ -31,7 +31,7 @@ class DatastreamProtocolTest extends AbstractProtocolTest
         $message = array(Protocol::REQUEST_INITDATA, 'Network', '1', 'k1', 'v1', 'k2', 'v2');
 
         // the actual message interpretation (in line with legacy protocol wire format)
-        $expected = array(Protocol::REQUEST_INITDATA, 'Network', '1', array('k1' => 'v1', 'k2' => 'v2'));
+        $expected = array(Protocol::REQUEST_INITDATA, 'Network', '1', (object)array('k1' => 'v1', 'k2' => 'v2'));
 
         $this->assertEquals($expected, $this->protocol->parseVariantPacket($this->protocol->serializeVariantPacket($message)));
     }

--- a/tests/Io/LegacyProtocolTest.php
+++ b/tests/Io/LegacyProtocolTest.php
@@ -26,7 +26,7 @@ class LegacyProtocolTest extends AbstractProtocolTest
             '1',
             $data = array(
                 'a' => 1,
-                'IrcUsersAndChannels' => array(),
+                'IrcUsersAndChannels' => (object)array(),
                 'b' => 2,
             )
         ));
@@ -36,8 +36,8 @@ class LegacyProtocolTest extends AbstractProtocolTest
         $values = $this->protocol->parseVariantPacket($packet);
 
         $this->assertCount(4, $values);
-        $this->assertCount(3, $values[3]);
-        $this->assertEquals($data, $values[3]);
+        $this->assertCount(3, (array)$values[3]);
+        $this->assertEquals($data, (array)$values[3]);
     }
 
     public function testInitDataNetworkUpcastToNewDatastreamFormat()
@@ -70,9 +70,9 @@ class LegacyProtocolTest extends AbstractProtocolTest
         $values = $this->protocol->parseVariantPacket($packet);
 
         $this->assertCount(4, $values);
-        $this->assertCount(3, $values[3]);
+        $this->assertCount(3, (array)$values[3]);
 
-        $expected = array('Users' => array(
+        $expected = (object)array('Users' => (object)array(
             'nick' => array(
                 'a',
                 'b'
@@ -82,7 +82,7 @@ class LegacyProtocolTest extends AbstractProtocolTest
                 false
             )
         ));
-        $this->assertEquals($expected, $values[3]['IrcUsersAndChannels']);
+        $this->assertEquals($expected, $values[3]->IrcUsersAndChannels);
     }
 
     /**


### PR DESCRIPTION
All map structures are now represented as `stdClass` object instead of assoc arrays. This only applies to object maps and lists will continue to be represented as arrays. This allows for a clear distinction between these concepts and allows you to differentiate between empty objects and empty lists. This is in line with how PHP's `json_decode()` function works.

This is a major BC break, see also the examples for more details on practical effect, for example:

```diff
- foreach ($message['SessionState']['NetworkIds'] as $nid) {
+ foreach ($message->SessionState->NetworkIds as $nid) {
```

Refs #40 and builds on top of #44 and https://github.com/clue/php-qdatastream/pull/32