### PR TITLE
Always represent message timestamps as DateTime objects

### DIFF
--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -63,7 +63,7 @@ $factory->createClient($uri)->then(function (Client $client) {
         if ($type === Protocol::REQUEST_RPCCALL && $message[1] === '2displayMsg(Message)') {
             $in = $message[2];
             assert($in instanceof Message);
-            echo date(DATE_ISO8601, $in->timestamp) . ' in ' . $in->bufferInfo->name . ' by ' . explode('!', $in->sender)[0] . ': ' . $in->contents . PHP_EOL;
+            echo $in->timestamp->format(DATE_ISO8601) . ' in ' . $in->bufferInfo->name . ' by ' . explode('!', $in->sender)[0] . ': ' . $in->contents . PHP_EOL;
 
             return;
         }

--- a/examples/05-backlog.php
+++ b/examples/05-backlog.php
@@ -67,7 +67,7 @@ $factory->createClient($uri)->then(function (Client $client) use ($channel) {
                 echo json_encode(
                     array(
                         'id' => $in->id,
-                        'date' => date(\DATE_ATOM, $in->timestamp),
+                        'date' => $in->timestamp->format(\DATE_ATOM),
                         'channel' => $in->bufferInfo->name,
                         'sender' => explode('!', $in->sender)[0],
                         'contents' => $in->contents

--- a/src/Io/Protocol.php
+++ b/src/Io/Protocol.php
@@ -74,9 +74,16 @@ abstract class Protocol
                 return $reader->readUInt();
             },
             'Message' => function (Reader $reader) {
+                $readTimestamp = function () use ($reader) {
+                    // create DateTime object with local time zone from unix timestamp
+                    $d = new \DateTime('@' . $reader->readUint());
+                    $d->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
+                    return $d;
+                };
+
                 return new Message(
                     $reader->readUInt(),
-                    $reader->readUInt(),
+                    $readTimestamp(),
                     $reader->readUInt(),
                     $reader->readUChar(),
                     $reader->readQUserTypeByName('BufferInfo'),

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -39,7 +39,7 @@ class Message
     public $id;
 
     /**
-     * @var int UNIX timestamp
+     * @var \DateTime
      */
     public $timestamp;
 
@@ -72,7 +72,7 @@ class Message
      * [Internal] Instantiation is handled internally and should not be called manually.
      *
      * @param int        $id
-     * @param int        $timestamp  UNIX timestamp
+     * @param \DateTime  $timestamp
      * @param int        $type       single type constant, see self::TYPE_* constants
      * @param int        $flags      bitmask of flag constants, see self::FLAG_* constants
      * @param BufferInfo $bufferInfo
@@ -80,7 +80,7 @@ class Message
      * @param string     $contents
      * @internal
      */
-    public function __construct($id, $timestamp, $type, $flags, BufferInfo $bufferInfo, $sender, $contents)
+    public function __construct($id, \DateTime $timestamp, $type, $flags, BufferInfo $bufferInfo, $sender, $contents)
     {
         $this->id = $id;
         $this->timestamp = $timestamp;

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -263,6 +263,7 @@ class FunctionalTest extends TestCase
         }
 
         $this->assertTrue($newest instanceof Message);
+        $this->assertInstanceOf('DateTime', $newest->timestamp);
 
         $client->close();
     }

--- a/tests/Models/MessageTest.php
+++ b/tests/Models/MessageTest.php
@@ -9,7 +9,7 @@ class MessageTest extends TestCase
         $buffer = $this->getMockBuilder('Clue\React\Quassel\Models\BufferInfo')->disableOriginalConstructor()->getMock();
         $message = new Message(
             1000,
-            1528039705,
+            new DateTime('@1528039705'),
             Message::TYPE_PLAIN,
             Message::FLAG_NONE,
             $buffer,
@@ -18,7 +18,7 @@ class MessageTest extends TestCase
         );
 
         $this->assertSame(1000, $message->id);
-        $this->assertSame(1528039705, $message->timestamp);
+        $this->assertSame(1528039705, $message->timestamp->getTimestamp());
         $this->assertSame(Message::TYPE_PLAIN, $message->type);
         $this->assertSame(Message::FLAG_NONE, $message->flags);
         $this->assertSame($buffer, $message->bufferInfo);
@@ -31,7 +31,7 @@ class MessageTest extends TestCase
         $buffer = $this->getMockBuilder('Clue\React\Quassel\Models\BufferInfo')->disableOriginalConstructor()->getMock();
         $message = new Message(
             999,
-            1528039704,
+            new DateTime('@1528039704'),
             Message::TYPE_JOIN,
             Message::FLAG_NONE,
             $buffer,
@@ -40,7 +40,7 @@ class MessageTest extends TestCase
         );
 
         $this->assertSame(999, $message->id);
-        $this->assertSame(1528039704, $message->timestamp);
+        $this->assertSame(1528039704, $message->timestamp->getTimestamp());
         $this->assertSame(Message::TYPE_JOIN, $message->type);
         $this->assertSame(Message::FLAG_NONE, $message->flags);
         $this->assertSame($buffer, $message->bufferInfo);


### PR DESCRIPTION
This makes consuming the timestamp property much easier and also automatically dumping a `DateTime` object in debug logs is more meaningful than some integer timestamp. On top of this, this library will support millisecond precision timestamps when connected to a Quassel v0.13+ core in the future (refs #45).

Builds on top of #41 and #44