### PR TITLE
Change IrcUsersAndChannels structure to its logic represenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,11 @@ There are only few noticable exceptions to this rule:
 *   The legacy protocol uses plain times for heartbeat messages while the newer
     datastream protocol uses `DateTime` objects.
     This library always converts this to `DateTime` for consistency reasons.
-*   The legacy protocol uses excessive map structures for initial "Network"
-    synchronization, while the newer datastream protocol users optimized list
-    structures to avoid repeatedly sending the same keys.
-    This library always exposes the legacy protocol format in the same way as
-    the newer datastream protocol for consistency reasons.
+*   The initial `Network` synchronization uses different structures for the
+    `IrcUsersAndChannels` format structures depending on which wire-protocol is
+    used. This library always exposes this structure in its simpler "logic" form
+    for consistency reasons. This means it always contains the keys `Users` and
+    `Channels` which both contain a list of objects decribing each element.
 
 This combined basically means that you should always get consistent `data`
 events for both the legacy protocol and the newer datastream protocol.

--- a/examples/01-channels.php
+++ b/examples/01-channels.php
@@ -53,16 +53,16 @@ $factory->createClient($uri)->then(function (Client $client) {
         if (isset($message[0]) && $message[0] === Protocol::REQUEST_INITDATA && $message[1] === 'Network') {
             // print network information except for huge users/channels list
             $info = clone $message[3];
-            unset($info->IrcUsersAndChannels);
+            //unset($info->IrcUsersAndChannels);
             echo json_encode($info, JSON_PRETTY_PRINT) . PHP_EOL;
 
             // print names of all known channels on this network (if connected)
-            if (isset($message[3]->IrcUsersAndChannels->Channels)) {
-                foreach ($message[3]->IrcUsersAndChannels->Channels->name as $name) {
-                    echo $name . PHP_EOL;
+            if ($message[3]->IrcUsersAndChannels->Channels) {
+                foreach ($message[3]->IrcUsersAndChannels->Channels as $channel) {
+                    echo $channel->name . PHP_EOL;
                 }
             } else {
-                echo 'No channels in ' . $message[3]->networkName . ' (disconnected)' . PHP_EOL;
+                echo 'No channels in ' . $message[3]->networkName . PHP_EOL;
             }
 
             // close connection after showing all networks


### PR DESCRIPTION
This makes consuming the `IrcUsersAndChannels` structure much easier and makes dumping this structure in debug logs more meaningful than the previous structure which was aligned on the network-optimized datastream format.

This refs #46 and #47 and builds on top of #48