### PR TITLE
Update PHPUnit configuration schema for PHPUnit 9.3 and support PHP 8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.gitignore export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - run: sudo /etc/init.d/quasselcore status || sudo /etc/init.d/quasselcore start
       - run: sudo /etc/init.d/quasselcore status || sleep 2
       - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
@@ -45,7 +48,6 @@ jobs:
           version: lts-3.30
       - run: sudo apt-get -qq update || true # update package list and ignore temporary network errors
       - run: sudo apt-get --no-install-recommends -qq install -y quassel-core
-      - run: hhvm $(which composer) require phpunit/phpunit:^5 --dev --no-interaction # requires legacy phpunit
       - run: hhvm $(which composer) install
       - run: sudo /etc/init.d/quasselcore status || sudo /etc/init.d/quasselcore start
       - run: sudo /etc/init.d/quasselcore status || sleep 2

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ $ composer require clue/quassel-react:^0.6
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
     },
     "require-dev": {
         "clue/block-react": "^1.1",
-        "phpunit/phpunit": "^7.0 || ^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
-        <testsuite name="Quassel React Test Suite">
+        <testsuite name="Quassel test suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Quassel Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,7 +10,15 @@ use React\Stream\ThroughStream;
 
 class ClientTest extends TestCase
 {
-    public function setUp()
+    private $stream;
+    private $protocol;
+    private $splitter;
+    private $client;
+
+    /**
+     * @before
+     */
+    public function setUpClient()
     {
         $this->stream = $this->getMockBuilder('React\Stream\DuplexStreamInterface')->getMock();
         $this->protocol = $this->getMockBuilder('Clue\React\Quassel\Io\Protocol')->disableOriginalConstructor()->getMock();
@@ -243,7 +251,7 @@ class ClientTest extends TestCase
             $that->assertEquals(Protocol::REQUEST_HEARTBEAT, $value[0]);
 
             $that->assertInstanceOf('DateTime', $value[1]);
-            $that->assertEquals(microtime(true), $value[1]->getTimestamp(), '', 2);
+            $that->assertEqualsDelta(microtime(true), $value[1]->getTimestamp(), 2);
             return true;
         }));
         $this->splitter->expects($this->once())->method('writePacket');

--- a/tests/FactoryIntegrationTest.php
+++ b/tests/FactoryIntegrationTest.php
@@ -86,9 +86,6 @@ class FactoryIntegrationTest extends TestCase
         Block\sleep(0.1, $loop);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCreateClientRejectsIfServerRespondsWithInvalidData()
     {
         $loop = LoopFactory::create();
@@ -104,6 +101,7 @@ class FactoryIntegrationTest extends TestCase
         $factory = new Factory($loop);
         $promise = $factory->createClient($uri);
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $loop, 10.0);
     }
 
@@ -132,9 +130,6 @@ class FactoryIntegrationTest extends TestCase
         Block\sleep(0.1, $loop);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCreateClientWithAuthRejectsIfServerClosesAfterClientInit()
     {
         $loop = LoopFactory::create();
@@ -153,12 +148,10 @@ class FactoryIntegrationTest extends TestCase
         $factory = new Factory($loop);
         $promise = $factory->createClient('user:pass@' . $uri);
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $loop, 10.0);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCreateClientWithAuthRejectsIfServerSendsClientInitRejectAfterClientInit()
     {
         $loop = LoopFactory::create();
@@ -182,12 +175,10 @@ class FactoryIntegrationTest extends TestCase
         $factory = new Factory($loop);
         $promise = $factory->createClient('user:pass@' . $uri);
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $loop, 10.0);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCreateClientWithAuthRejectsIfServerSendsUnknownMessageAfterClientInit()
     {
         $loop = LoopFactory::create();
@@ -211,12 +202,10 @@ class FactoryIntegrationTest extends TestCase
         $factory = new Factory($loop);
         $promise = $factory->createClient('user:pass@' . $uri);
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $loop, 10.0);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCreateClientWithAuthRejectsIfServerSendsInvalidTruncatedResponseAfterClientInit()
     {
         $loop = LoopFactory::create();
@@ -235,12 +224,10 @@ class FactoryIntegrationTest extends TestCase
         $factory = new Factory($loop);
         $promise = $factory->createClient('user:pass@' . $uri);
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $loop, 10.0);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCreateClientWithAuthRejectsIfServerSendsClientInitAckNotConfigured()
     {
         $loop = LoopFactory::create();
@@ -263,6 +250,7 @@ class FactoryIntegrationTest extends TestCase
         $factory = new Factory($loop);
         $promise = $factory->createClient('user:pass@' . $uri);
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, $loop, 10.0);
     }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -9,7 +9,15 @@ use React\Promise;
 
 class FactoryTest extends TestCase
 {
-    public function setUp()
+    private $loop;
+    private $connector;
+    private $prober;
+    private $factory;
+
+    /**
+     * @before
+     */
+    public function setUpFactory()
     {
         $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $this->connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -20,7 +20,10 @@ class FunctionalTest extends TestCase
     private static $loop;
     private static $blocker;
 
-    public static function setUpBeforeClass()
+    /**
+     * @beforeClass
+     */
+    public static function setUpEnvironmentAndLoop()
     {
         if (!getenv('QUASSEL_HOST')) {
             return;
@@ -40,7 +43,10 @@ class FunctionalTest extends TestCase
         self::$loop = LoopFactory::create();
     }
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpSkipOnMissingEnvironment()
     {
         if (!self::$host) {
             $this->markTestSkipped('No ENV QUASSEL_HOST (plus optionally QUASSEL_USER and QUASSEL_PASS) given');
@@ -170,7 +176,7 @@ class FunctionalTest extends TestCase
         $received = Block\await($promise, self::$loop, 10.0);
 
         $this->assertTrue($received instanceof \DateTime);
-        $this->assertEquals(microtime(true), $received->getTimestamp(), '', 2.0);
+        $this->assertEqualsDelta(microtime(true), $received->getTimestamp(), 2.0);
     }
 
     /**
@@ -274,9 +280,6 @@ class FunctionalTest extends TestCase
         $client->close();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testCreateClientWithInvalidAuthUrlRejects()
     {
         $factory = new Factory(self::$loop);
@@ -284,6 +287,7 @@ class FunctionalTest extends TestCase
         $url = rawurlencode(self::$username) . ':@' . self::$host;
         $promise = $factory->createClient($url);
 
+        $this->setExpectedException('RuntimeException');
         Block\await($promise, self::$loop, 10.0);
     }
 

--- a/tests/Io/DatastreamProtocolTest.php
+++ b/tests/Io/DatastreamProtocolTest.php
@@ -9,7 +9,10 @@ use Clue\QDataStream\Types;
 
 class DatastreamProtocolTest extends AbstractProtocolTest
 {
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpProtocol()
     {
         $this->protocol = Protocol::createFromProbe(Protocol::TYPE_DATASTREAM);
     }
@@ -19,11 +22,9 @@ class DatastreamProtocolTest extends AbstractProtocolTest
         $this->assertFalse($this->protocol->isLegacy());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCanNotTransportListStartingWithString()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->protocol->serializeVariantPacket(array('does', 'not', 'work'));
     }
 

--- a/tests/Io/LegacyProtocolTest.php
+++ b/tests/Io/LegacyProtocolTest.php
@@ -9,7 +9,10 @@ use Clue\QDataStream\Types;
 
 class LegacyProtocolTest extends AbstractProtocolTest
 {
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpProtocol()
     {
         $this->protocol = Protocol::createFromProbe(Protocol::TYPE_LEGACY);
     }

--- a/tests/Io/PacketSplitterTest.php
+++ b/tests/Io/PacketSplitterTest.php
@@ -9,7 +9,10 @@ class PacketSplitterTest extends TestCase
 {
     private $splitter;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpSplitter()
     {
         $this->splitter = new PacketSplitter();
     }
@@ -29,11 +32,9 @@ class PacketSplitterTest extends TestCase
         $this->splitter->push($packet, $this->expectCallableOnce());
     }
 
-    /**
-     * @expectedException OverflowException
-     */
     public function testWillThrowForHugePacket()
     {
+        $this->setExpectedException('OverflowException');
         $this->splitter->push("\xFF\xFF\xFF\xFF", $this->expectCallableNever());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,4 +59,32 @@ class TestCase extends BaseTestCase
 
         return $promise;
     }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 6+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
+
+    public function assertEqualsDelta($expected, $actual, $delta, $message = '')
+    {
+        if (method_exists($this, 'assertEqualsWithDelta')) {
+            // PHPUnit 7.5+
+            $this->assertEqualsWithDelta($expected, $actual, $delta, $message);
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 7.4
+            $this->assertEquals($expected, $actual, $message, $delta);
+        }
+    }
 }


### PR DESCRIPTION
Refs https://github.com/clue/php-qdatastream/pull/38 and https://github.com/graphp/graphviz/pull/46

It's now possible to run this code with PHP 8 🎉

 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0-cli php vendor/bin/phpunit
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

...................................................SSSSSSSSSS.... 65 / 91 ( 71%)
..........................                                        91 / 91 (100%)

Time: 00:01.156, Memory: 10.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 91, Assertions: 164, Skipped: 10.
```