### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,34 @@ the [examples](examples) to get started.
 ### Factory
 
 The `Factory` is responsible for creating your [`Client`](#client) instance.
-It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
 
 ```php
-$loop = \React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Clue\React\Quassel\Factory();
 ```
 
-If you need custom DNS, proxy or TLS settings, you can explicitly pass a
-custom instance of the [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
+This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use for this object. You can use a `null` value
+here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+This value SHOULD NOT be given unless you're sure you want to explicitly use a
+given event loop instance.
+
+If you need custom connector settings (DNS resolution, TLS parameters, timeouts,
+proxy servers etc.), you can explicitly pass a custom instance of the
+[`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$factory = new Factory($loop, $connector);
+$connector = new React\Socket\Connector(null, array(
+    'dns' => '127.0.0.1',
+    'tcp' => array(
+        'bindto' => '192.168.10.1:0'
+    ),
+    'tls' => array(
+        'verify_peer' => false,
+        'verify_peer_name' => false
+    )
+));
+
+$factory = new Clue\React\Quassel\Factory(null, $connector);
 ```
 
 #### createClient()

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     "require": {
     	"php": ">=5.3",
         "clue/qdatastream": "^0.8",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.2",
         "react/promise": "~2.0|~1.1",
-        "react/socket": "^1.0 || ^0.8 || ^0.7",
-        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.6"
+        "react/socket": "^1.8",
+        "react/stream": "^1.2"
     },
     "require-dev": {
         "clue/block-react": "^1.1",

--- a/examples/01-channels.php
+++ b/examples/01-channels.php
@@ -17,8 +17,7 @@ $user = trim(fgets(STDIN));
 echo 'Password: ';
 $pass = trim(fgets(STDIN));
 
-$loop = \React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
@@ -90,5 +89,3 @@ $factory->createClient($uri)->then(function (Client $client) {
 })->then(null, function ($e) {
     echo $e;
 });
-
-$loop->run();

--- a/examples/02-chatbot.php
+++ b/examples/02-chatbot.php
@@ -25,8 +25,7 @@ if (strlen($keyword) < 3) {
     die('Keyword MUST contain at least 3 characters to avoid excessive spam');
 }
 
-$loop = \React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
@@ -61,5 +60,3 @@ $factory->createClient($uri)->then(function (Client $client) use ($keyword) {
 })->then(null, function ($e) {
     echo $e;
 });
-
-$loop->run();

--- a/examples/03-pingbot.php
+++ b/examples/03-pingbot.php
@@ -19,8 +19,7 @@ $user = trim(fgets(STDIN));
 echo 'Password: ';
 $pass = trim(fgets(STDIN));
 
-$loop = \React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
@@ -127,5 +126,3 @@ $factory->createClient($uri)->then(function (Client $client) {
 })->then(null, function ($e) {
     echo $e;
 });
-
-$loop->run();

--- a/examples/04-connect.php
+++ b/examples/04-connect.php
@@ -19,8 +19,7 @@ $user = trim(fgets(STDIN));
 echo 'Password: ';
 $pass = trim(fgets(STDIN));
 
-$loop = \React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
@@ -88,5 +87,3 @@ $factory->createClient($uri)->then(function (Client $client) {
 })->then(null, function ($e) {
     echo $e;
 });
-
-$loop->run();

--- a/examples/05-backlog.php
+++ b/examples/05-backlog.php
@@ -22,8 +22,7 @@ $pass = trim(fgets(STDIN));
 echo 'Channel to export (empty=all): ';
 $channel = trim(fgets(STDIN));
 
-$loop = \React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $uri = rawurlencode($user) . ':' . rawurlencode($pass) . '@' . $host;
 
@@ -96,5 +95,3 @@ $factory->createClient($uri)->then(function (Client $client) use ($channel) {
 })->then(null, function ($e) {
     echo $e;
 });
-
-$loop->run();

--- a/examples/11-debug.php
+++ b/examples/11-debug.php
@@ -2,7 +2,6 @@
 
 use Clue\React\Quassel\Factory;
 use Clue\React\Quassel\Client;
-use Clue\React\Quassel\Io\Protocol;
 use Clue\React\Quassel\Models\BufferInfo;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -19,8 +18,7 @@ $user['name'] = trim(fgets(STDIN));
 echo 'Password: ';
 $user['password'] = trim(fgets(STDIN));
 
-$loop = \React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 echo '[1/5] Connecting' . PHP_EOL;
 $factory->createClient($host)->then(function (Client $client) use ($user) {
@@ -110,5 +108,3 @@ $factory->createClient($host)->then(function (Client $client) use ($user) {
 })->then(null, function ($e) {
     echo $e;
 });
-
-$loop->run();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -4,6 +4,7 @@ namespace Clue\React\Quassel;
 
 use Clue\React\Quassel\Io\Prober;
 use Clue\React\Quassel\Io\Protocol;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise;
 use React\Socket\ConnectorInterface;
@@ -13,15 +14,24 @@ use InvalidArgumentException;
 
 class Factory
 {
-    public function __construct(LoopInterface $loop, ConnectorInterface $connector = null, Prober $prober = null)
+    /** @var LoopInterface */
+    private $loop;
+
+    /** @var ConnectorInterface */
+    private $connector;
+
+    /** @var Prober */
+    private $prober;
+
+    public function __construct(LoopInterface $loop = null, ConnectorInterface $connector = null, Prober $prober = null)
     {
+        $this->loop = $loop ?: Loop::get();
         if ($connector === null) {
             $connector = new Connector($loop);
         }
         if ($prober === null) {
             $prober = new Prober();
         }
-        $this->loop = $loop;
         $this->connector = $connector;
         $this->prober = $prober;
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -31,7 +31,18 @@ class FactoryTest extends TestCase
      */
     public function testCtorOptionalArgs()
     {
-        new Factory($this->loop);
+        new Factory();
+    }
+
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $factory = new Factory();
+
+        $ref = new \ReflectionProperty($factory, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($factory);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
     }
 
     public function testPassHostnameAndDefaultPortToConnector()

--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -2,14 +2,14 @@
 
 namespace Clue\Tests\React\Quassel;
 
-use React\EventLoop\Factory as LoopFactory;
-use Clue\React\Quassel\Factory;
 use Clue\React\Block;
 use Clue\React\Quassel\Client;
-use React\Promise\Promise;
+use Clue\React\Quassel\Factory;
 use Clue\React\Quassel\Io\Protocol;
 use Clue\React\Quassel\Models\BufferInfo;
 use Clue\React\Quassel\Models\Message;
+use React\EventLoop\Loop;
+use React\Promise\Promise;
 
 class FunctionalTest extends TestCase
 {
@@ -17,7 +17,6 @@ class FunctionalTest extends TestCase
     private static $username;
     private static $password;
 
-    private static $loop;
     private static $blocker;
 
     /**
@@ -39,8 +38,6 @@ class FunctionalTest extends TestCase
         if (!self::$password) {
             self::$password = 'quassel';
         }
-
-        self::$loop = LoopFactory::create();
     }
 
     /**
@@ -58,10 +55,10 @@ class FunctionalTest extends TestCase
      */
     public function testCreateClient()
     {
-        $factory = new Factory(self::$loop);
+        $factory = new Factory();
         $promise = $factory->createClient(self::$host);
 
-        $client = Block\await($promise, self::$loop, 10.0);
+        $client = Block\await($promise, Loop::get(), 10.0);
 
         return $client;
     }
@@ -148,7 +145,7 @@ class FunctionalTest extends TestCase
 
         $client->writeHeartBeatRequest($time);
 
-        $received = Block\await($promise, self::$loop, 10.0);
+        $received = Block\await($promise, Loop::get(), 10.0);
 
         $this->assertEquals($time, $received);
     }
@@ -173,7 +170,7 @@ class FunctionalTest extends TestCase
 
         $client->writeHeartBeatRequest();
 
-        $received = Block\await($promise, self::$loop, 10.0);
+        $received = Block\await($promise, Loop::get(), 10.0);
 
         $this->assertTrue($received instanceof \DateTime);
         $this->assertEqualsDelta(microtime(true), $received->getTimestamp(), 2.0);
@@ -191,16 +188,16 @@ class FunctionalTest extends TestCase
 
         $client->close();
 
-        return Block\await($promise, self::$loop, 10.0);
+        return Block\await($promise, Loop::get(), 10.0);
     }
 
     public function testCreateClientWithAuthUrlReceivesSessionInit()
     {
-        $factory = new Factory(self::$loop);
+        $factory = new Factory();
 
         $url = rawurlencode(self::$username) . ':' . rawurlencode(self::$password) . '@' . self::$host;
         $promise = $factory->createClient($url);
-        $client = Block\await($promise, self::$loop, 10.0);
+        $client = Block\await($promise, Loop::get(), 10.0);
 
         $message = $this->awaitMessage($client);
         $this->assertEquals('SessionInit', $message->MsgType);
@@ -210,11 +207,11 @@ class FunctionalTest extends TestCase
 
     public function testRequestBacklogReceivesBacklog()
     {
-        $factory = new Factory(self::$loop);
+        $factory = new Factory();
 
         $url = rawurlencode(self::$username) . ':' . rawurlencode(self::$password) . '@' . self::$host;
         $promise = $factory->createClient($url);
-        $client = Block\await($promise, self::$loop, 10.0);
+        $client = Block\await($promise, Loop::get(), 10.0);
         /* @var $client Client */
 
         $message = $this->awaitMessage($client);
@@ -282,13 +279,13 @@ class FunctionalTest extends TestCase
 
     public function testCreateClientWithInvalidAuthUrlRejects()
     {
-        $factory = new Factory(self::$loop);
+        $factory = new Factory();
 
         $url = rawurlencode(self::$username) . ':@' . self::$host;
         $promise = $factory->createClient($url);
 
         $this->setExpectedException('RuntimeException');
-        Block\await($promise, self::$loop, 10.0);
+        Block\await($promise, Loop::get(), 10.0);
     }
 
     private function awaitMessage(Client $client)
@@ -298,6 +295,6 @@ class FunctionalTest extends TestCase
 
             $client->once('error', $reject);
             $client->once('close', $reject);
-        }), self::$loop, 10.0);
+        }), Loop::get(), 10.0);
     }
 }


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$factory = new Clue\React\Quassel\Factory($loop);

// new (using default loop)
$factory = new Clue\React\Quassel\Factory();
```

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229, https://github.com/reactphp/event-loop/pull/232 and https://github.com/reactphp/socket/pull/260
Also builds on top of #53 to skip tests that exhibit a rare race condition