### PR TITLE
Simplify tests by supporting new Socket API

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ proxy servers etc.), you can explicitly pass a custom instance of the
 [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface):
 
 ```php
-$connector = new React\Socket\Connector(null, array(
+$connector = new React\Socket\Connector(array(
     'dns' => '127.0.0.1',
     'tcp' => array(
         'bindto' => '192.168.10.1:0'

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "clue/qdatastream": "^0.8",
         "react/event-loop": "^1.2",
         "react/promise": "~2.0|~1.1",
-        "react/socket": "^1.8",
+        "react/socket": "^1.9",
         "react/stream": "^1.2"
     },
     "require-dev": {

--- a/tests/FactoryIntegrationTest.php
+++ b/tests/FactoryIntegrationTest.php
@@ -7,14 +7,14 @@ use Clue\React\Quassel\Client;
 use Clue\React\Quassel\Factory;
 use Clue\React\Quassel\Io\Protocol;
 use React\EventLoop\Loop;
-use React\Socket\Server;
+use React\Socket\SocketServer;
 use React\Socket\ConnectionInterface;
 
 class FactoryIntegrationTest extends TestCase
 {
     public function testCreateClientCreatesConnection()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
         $server->on('connection', $this->expectCallableOnce());
 
         $uri = str_replace('tcp://', '', $server->getAddress());
@@ -26,7 +26,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientSendsProbeOverConnection()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $data = $this->expectCallableOnceWith("\x42\xb3\x3f\x00" . "\x00\x00\x00\x02" . "\x80\x00\x00\x01");
         $server->on('connection', function (ConnectionInterface $conn) use ($data) {
@@ -42,7 +42,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientResolvesIfServerRespondsWithProbeResponse()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $server->on('connection', function (ConnectionInterface $conn) {
             $conn->on('data', function () use ($conn) {
@@ -62,7 +62,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientCreatesSecondConnectionWithoutProbeIfConnectionClosesDuringProbe()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $once = $this->expectCallableOnce();
         $server->on('connection', function (ConnectionInterface $conn) use ($once) {
@@ -81,7 +81,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientRejectsIfServerRespondsWithInvalidData()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $server->on('connection', function (ConnectionInterface $conn) {
             $conn->on('data', function () use ($conn) {
@@ -99,7 +99,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientWithAuthSendsClientInitAfterProbe()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $data = $this->expectCallableOnceWith($this->callback(function ($packet) {
             $data = FactoryIntegrationTest::decode($packet);
@@ -123,7 +123,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientWithAuthRejectsIfServerClosesAfterClientInit()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $server->on('connection', function (ConnectionInterface $conn) {
             $conn->on('data', function () use ($conn) {
@@ -144,7 +144,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientWithAuthRejectsIfServerSendsClientInitRejectAfterClientInit()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $server->on('connection', function (ConnectionInterface $conn) {
             $conn->once('data', function () use ($conn) {
@@ -170,7 +170,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientWithAuthRejectsIfServerSendsUnknownMessageAfterClientInit()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $server->on('connection', function (ConnectionInterface $conn) {
             $conn->once('data', function () use ($conn) {
@@ -196,7 +196,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientWithAuthRejectsIfServerSendsInvalidTruncatedResponseAfterClientInit()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $server->on('connection', function (ConnectionInterface $conn) {
             $conn->once('data', function () use ($conn) {
@@ -217,7 +217,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientWithAuthRejectsIfServerSendsClientInitAckNotConfigured()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $server->on('connection', function (ConnectionInterface $conn) {
             $conn->once('data', function () use ($conn) {
@@ -242,7 +242,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientWithAuthSendsClientLoginAfterClientInit()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         // expect login packet
         $data = $this->expectCallableOnceWith($this->callback(function ($packet) {
@@ -277,7 +277,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientRespondsWithHeartBeatResponseAfterHeartBeatRequest()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         // expect heartbeat response packet
         $data = $this->expectCallableOnceWith($this->callback(function ($packet) {
@@ -316,7 +316,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientDoesNotRespondWithHeartBeatResponseIfPongIsDisabled()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         // expect no message in response
         $data = $this->expectCallableNever();
@@ -350,7 +350,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientSendsHeartBeatRequestAtInterval()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         // expect heartbeat response packet
         $data = $this->expectCallableOnceWith($this->callback(function ($packet) {
@@ -381,7 +381,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientSendsNoHeartBeatRequestIfServerKeepsSendingMessages()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         // expect heartbeat response packet
         $data = $this->expectCallableNever();
@@ -412,7 +412,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientClosesWithErrorIfServerDoesNotRespondToHeartBeatRequests()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         $server->on('connection', function (ConnectionInterface $conn) {
             $conn->once('data', function () use ($conn) {
@@ -433,7 +433,7 @@ class FactoryIntegrationTest extends TestCase
 
     public function testCreateClientSendsNoHeartBeatRequestIfPingIsDisabled()
     {
-        $server = new Server(0);
+        $server = new SocketServer('127.0.0.1:0');
 
         // expect heartbeat response packet
         $data = $this->expectCallableNever();


### PR DESCRIPTION
This changeset simplifies tests by supporting the new Socket API with the new `SocketServer`.
```php
// old (still supported)
$server = new React\Socket\Server(0);

// new
$server = new React\Socket\SocketServer('127.0.0.1:0');
```
Note that this doesn't affect the API of this package at all, but does use the improved API of the referenced Socket component. Existing code continues to work as is.

Together with #56,  we can now fully rely on the default loop and no longer need to skip any arguments with null values.

Builds on top of reactphp/socket#264 and reactphp/socket#263
